### PR TITLE
fix: release please job syntax

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,11 +25,9 @@ jobs:
           default-branch: main
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false}]'
   publish:
-    runs-on: ubuntu-latest
     name: Publish to pub.dev
     permissions:
       id-token: write # Required for authentication using OIDC
     needs: [release-please]
     if: needs.release-please.outputs.release_created == 'true'
-    steps:
-      - uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1


### PR DESCRIPTION
Seeing this error message when the action runs

```
reusable workflows should be referenced at the top-level `jobs.*.uses' key, not within steps
```