### PR TITLE
fix: allow heirarchal loggers to have their own log levels

### DIFF
--- a/lib/src/cache_client.dart
+++ b/lib/src/cache_client.dart
@@ -3,8 +3,9 @@ import 'package:momento/src/config/cache_configuration.dart';
 import 'package:momento/src/errors/errors.dart';
 import 'package:momento/src/internal/control_client.dart';
 import 'package:momento/src/internal/data_client.dart';
-import 'package:logging/logging.dart';
 import 'package:momento/src/internal/utils/validators.dart';
+
+import 'config/logger.dart';
 
 // import 'config/logger.dart';
 
@@ -26,15 +27,14 @@ abstract class ICacheClient {
 class CacheClient implements ICacheClient {
   late final DataClient _dataClient;
   late final ControlClient _controlClient;
-  final Logger _logger = Logger('MomentoCacheClient');
+  final MomentoLogger _logger = MomentoLogger('MomentoCacheClient');
 
   CacheClient(CredentialProvider credentialProvider,
       CacheConfiguration configuration, Duration defaultTtl) {
     _dataClient = DataClient(credentialProvider, configuration, defaultTtl);
     _controlClient = ControlClient(credentialProvider, configuration);
-    // TODO: fix logging level issue
-    // _logger.level = determineLoggerLevel(configuration.logLevel);
-    _logger.finest("initializing cache client");
+    _logger.setLevel(configuration.logLevel);
+    _logger.trace("initializing cache client");
   }
 
   @override

--- a/lib/src/config/logger.dart
+++ b/lib/src/config/logger.dart
@@ -28,3 +28,40 @@ Level determineLoggerLevel(LogLevel logLevel) {
       return Level.OFF;
   }
 }
+
+class MomentoLogger {
+  final Logger _logger;
+
+  MomentoLogger(String name) : _logger = Logger(name) {
+    Logger.root.level = Level.ALL;
+    hierarchicalLoggingEnabled = true;
+  }
+
+  void trace(String message) {
+    _logger.finest(message);
+  }
+
+  void debug(String message) {
+    _logger.fine(message);
+  }
+
+  void info(String message) {
+    _logger.info(message);
+  }
+
+  void warn(String message) {
+    _logger.warning(message);
+  }
+
+  void error(String message) {
+    _logger.severe(message);
+  }
+
+  void fatal(String message) {
+    _logger.shout(message);
+  }
+
+  void setLevel(LogLevel logLevel) {
+    _logger.level = determineLoggerLevel(logLevel);
+  }
+}

--- a/lib/src/topic_client.dart
+++ b/lib/src/topic_client.dart
@@ -1,6 +1,5 @@
 import 'package:momento/src/auth/credential_provider.dart';
-// import 'package:client_sdk_dart/src/config/logger.dart';
-import 'package:logging/logging.dart';
+import 'package:momento/src/config/logger.dart';
 import 'config/topic_configuration.dart';
 import 'internal/pubsub_client.dart';
 import 'messages/responses/topics/topic_subscribe.dart';
@@ -18,14 +17,13 @@ abstract class ITopicClient {
 
 class TopicClient implements ITopicClient {
   final ClientPubsub _pubsubClient;
-  final Logger _logger = Logger('MomentoTopicClient');
+  final MomentoLogger _logger = MomentoLogger('MomentoTopicClient');
 
   TopicClient(
       CredentialProvider credentialProvider, TopicConfiguration configuration)
       : _pubsubClient = ClientPubsub(credentialProvider, configuration) {
-    // TODO: fix logging level issue
-    // _logger.level = determineLoggerLevel(configuration.logLevel);
-    _logger.finest("initializing topic client");
+    _logger.setLevel(configuration.logLevel);
+    _logger.trace("initializing topic client");
   }
 
   @override


### PR DESCRIPTION
closes #36 

Tested by running the topics example, and it was able to successfully publish messages

```
cd examples/topics
MOMENTO_API_KEY="your-api-key" dart run basic_publisher.dart
```