### PR TITLE
chore: add readme template and readme generator ci steps

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -1,9 +1,4 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-name: Dart
+name: Pull Request
 
 on:
   pull_request:

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -6,8 +6,6 @@
 name: Dart
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 
@@ -42,3 +40,19 @@ jobs:
         run: dart test
         env:
           TEST_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+  
+  readme:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Verify README generation
+        uses: momentohq/standards-and-practices/github-actions/oss-readme-template@gh-actions-v2
+        with:
+          project_status: official
+          project_stability: alpha
+          project_type: sdk
+          sdk_language: Dart
+          template_file: ./README.template.md
+          output_file: ./README.md
+          dev_docs_slug: dart

--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -1,0 +1,31 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Dart
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup repo
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
+
+      - name: Generate README
+        uses: momentohq/standards-and-practices/github-actions/oss-readme-template@gh-actions-v2
+        with:
+          project_status: official
+          project_stability: alpha
+          project_type: sdk
+          sdk_language: Dart
+          template_file: ./README.template.md
+          output_file: ./README.md
+          dev_docs_slug: dart

--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -1,9 +1,4 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-name: Dart
+name: Push to Main
 
 on:
   push:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Welcome to client-sdk-dart contributing guide :wave:
+
+Thank you for taking your time to contribute to our Dart SDK!
+<br/>
+This guide will provide you information to start your own development and testing.
+<br/>
+Happy coding :dancer:
+<br/>
+
+## Requirements :coffee:
+
+- Dart version [3 or higher](https://dart.dev/get-dart) is required.
+- A Momento API key is required, you can generate one using the [Momento Console](https://console.gomomento.com/api-keys)
+
+<br/>
+
+## Developer Setup
+
+If you're using the IntelliJ IDE for development, you may want to install the [dart plugin](https://plugins.jetbrains.com/plugin/6351-dart). 
+
+To install the repository's dependencies, run `dart pub get`.
+
+To lint your files while developing, run `dart format .` from the root of the repository.
+
+## Examples
+
+All examples are in subdirectories of `example`. We currently have a publish-and-subscribe example app in [example/topics](./example/topics/) that demonstrates how to use the Momento Topic Client to both publish and subscribe to a topic, as well as an example Flutter app in [example/flutter_chat_app](./example/flutter_chat_app/) that uses Momento Topics to create a chat app demo.
+
+## Build :computer:
+
+You can build the SDK for a specific platform using the [`dart compile`](https://dart.dev/tools/dart-compile) command from the root of the repository.
+
+## Running tests
+
+You can use the this command from the root of the repository to run the tests:
+
+```bash
+TEST_API_KEY=<your api key> dart test
+```

--- a/README.template.md
+++ b/README.template.md
@@ -11,7 +11,7 @@ To get started with Momento you will need a Momento API key. You can get one fro
 
 ## Packages
 
-The Momento Dart SDK is available here: https://pub.dev/packages/momento 
+The Momento Dart SDK is available on [pub.dev](https://pub.dev/packages/momento) 
 
 To install in your Dart program, use: 
 

--- a/README.template.md
+++ b/README.template.md
@@ -1,0 +1,66 @@
+{{ ossHeader }}
+
+# Momento Dart SDK
+
+To get started with Momento you will need a Momento API key. You can get one from the [Momento Console](https://console.gomomento.com/api-keys).
+
+* Website: [https://www.gomomento.com/](https://www.gomomento.com/)
+* Momento Documentation: [https://docs.momentohq.com/](https://docs.momentohq.com/)
+* Getting Started: [https://docs.momentohq.com/getting-started](https://docs.momentohq.com/getting-started)
+* Discuss: [Momento Discord](https://discord.gg/3HkAKjUZGq)
+
+## Packages
+
+The Momento Dart SDK is available here: https://pub.dev/packages/momento 
+
+To install in your Dart program, use: 
+
+```bash
+dart pub add momento
+```
+
+To install in your Flutter program, use: 
+
+```bash
+flutter pub add momento
+```
+
+## Usage
+
+Check out our [example](./example/) directory for complete examples of using the Momento Dart SDK to implement a publish and subscribe system in a basic Dart program and in a Flutter app.
+
+Here is a quickstart you can use for your own project:
+
+{% include "./example/quickstart/quickstart.dart" %}
+
+## Getting Started and Documentation
+
+General documentation on Momento and the Momento SDKs is available on the [Momento Docs website](https://docs.momentohq.com/). Specific usage examples for the Dart SDK are coming soon!
+
+## Examples
+
+Check out full working code in the [example](./example/) directory of this repository!
+
+## Logging
+
+There is a `LogLevel` enum that contains the following log levels:
+
+* `LogLevel.trace`
+* `LogLevel.debug`
+* `LogLevel.info`
+* `LogLevel.warn`
+* `LogLevel.error`
+* `LogLevel.fatal`
+* `LogLevel.off`
+
+This enum can be used to configure the logging level of the Momento package. By default, the logging level is set to `LogLevel.info`. To change the logging level, pass the desired level to the `Configuration` constructor:
+
+```dart
+var config = Mobile.latest(logLevel: LogLevel.debug);
+```
+
+## Developing
+
+If you are interested in contributing to the SDK, please see the [CONTRIBUTING](./CONTRIBUTING.md) docs.
+
+{{ ossFooter }}

--- a/example/quickstart/quickstart.dart
+++ b/example/quickstart/quickstart.dart
@@ -1,0 +1,33 @@
+import 'dart:io';
+import 'package:momento/momento.dart';
+
+void main() async {
+  final cacheClient = CacheClient(
+      CredentialProvider.fromEnvironmentVariable("MOMENTO_API_KEY"),
+      MobileCacheConfiguration.latest(),
+      Duration(seconds: 30));
+
+  final cacheName = "cache";
+  final key = StringValue("key");
+  final value = StringValue("value");
+
+  final setResp = await cacheClient.set(cacheName, key, value);
+  switch (setResp) {
+    case SetSuccess():
+      print("Set successful!");
+    case SetError():
+      print("Set error: ${setResp.errorCode} ${setResp.message}");
+  }
+
+  final getResp = await cacheClient.get(cacheName, key);
+  switch (getResp) {
+    case GetHit():
+      print("Found value in $cacheName: ${getResp.value}");
+    case GetMiss():
+      print("Value was not found in $cacheName!");
+    case GetError():
+      print("Got an error: ${getResp.errorCode} ${getResp.message}");
+  }
+
+  exit(0);
+}


### PR DESCRIPTION
addresses #28 

adds readme template, contributing doc, and quickstart example to embed in the reamde. Also adds readme generator verification and generation steps in ci, but had to split those out into pull request vs push to main files.