### PR TITLE
feat: add CacheClient close method

### DIFF
--- a/example/quickstart/quickstart.dart
+++ b/example/quickstart/quickstart.dart
@@ -1,7 +1,8 @@
 import 'dart:io';
+import 'package:grpc/grpc.dart';
 import 'package:momento/momento.dart';
 
-void main() async {
+Future<void> main() async {
   final cacheClient = CacheClient(
       CredentialProvider.fromEnvironmentVariable("MOMENTO_API_KEY"),
       MobileCacheConfiguration.latest(),
@@ -29,5 +30,5 @@ void main() async {
       print("Got an error: ${getResp.errorCode} ${getResp.message}");
   }
 
-  exit(0);
+  await cacheClient.close();
 }

--- a/example/quickstart/quickstart.dart
+++ b/example/quickstart/quickstart.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-import 'package:grpc/grpc.dart';
 import 'package:momento/momento.dart';
 
 Future<void> main() async {

--- a/example/topics/advanced.dart
+++ b/example/topics/advanced.dart
@@ -71,5 +71,4 @@ void main() async {
 
   topicClient.close();
   print("End of Momento topics example");
-  exit(0);
 }

--- a/example/topics/basic_publisher.dart
+++ b/example/topics/basic_publisher.dart
@@ -21,5 +21,4 @@ void main() async {
 
   topicClient.close();
   print("Closed Momento Topics publisher");
-  exit(0);
 }

--- a/example/topics/basic_subscriber.dart
+++ b/example/topics/basic_subscriber.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 import 'package:momento/momento.dart';
 
 void main() async {

--- a/example/topics/basic_subscriber.dart
+++ b/example/topics/basic_subscriber.dart
@@ -38,5 +38,4 @@ void main() async {
 
   topicClient.close();
   print("Closed Momento Topics subscriber");
-  exit(0);
 }

--- a/lib/src/cache_client.dart
+++ b/lib/src/cache_client.dart
@@ -22,6 +22,8 @@ abstract class ICacheClient {
       {Duration? ttl});
 
   Future<DeleteResponse> delete(String cacheName, Value key);
+
+  Future<void> close();
 }
 
 class CacheClient implements ICacheClient {
@@ -116,5 +118,11 @@ class CacheClient implements ICacheClient {
       }
     }
     return _dataClient.delete(cacheName, key);
+  }
+
+  @override
+  Future<void> close() async {
+    await _dataClient.close();
+    await _controlClient.close();
   }
 }

--- a/lib/src/internal/control_client.dart
+++ b/lib/src/internal/control_client.dart
@@ -10,6 +10,8 @@ abstract class AbstractControlClient {
   Future<DeleteCacheResponse> deleteCache(String cacheName);
 
   Future<ListCachesResponse> listCaches();
+
+  Future<void> close();
 }
 
 class ControlClient implements AbstractControlClient {
@@ -82,5 +84,10 @@ class ControlClient implements AbstractControlClient {
             UnknownException("Unexpected error: $e", null, null));
       }
     }
+  }
+
+  @override
+  Future<void> close() async {
+    await _channel.shutdown();
   }
 }

--- a/lib/src/internal/data_client.dart
+++ b/lib/src/internal/data_client.dart
@@ -12,6 +12,8 @@ abstract class AbstractDataClient {
       {Duration? ttl});
 
   Future<DeleteResponse> delete(String cacheName, Value key);
+
+  Future<void> close();
 }
 
 class DataClient implements AbstractDataClient {
@@ -99,5 +101,10 @@ class DataClient implements AbstractDataClient {
             UnknownException("Unexpected error: $e", null, null));
       }
     }
+  }
+
+  @override
+  Future<void> close() async {
+    await _channel.shutdown();
   }
 }


### PR DESCRIPTION
addresses #66 

Examples would hang if `exit(0)` was not called at the end. Added a `close` method to the `CacheClient` to free up GRPC resources at the end of a program, so now `exit(0)` does not have to be called.
