### PR TITLE
fix: subscription error handling should expect async stream to throw errors, not TopicSubscriptionItem to return errors

### DIFF
--- a/example/topics/advanced.dart
+++ b/example/topics/advanced.dart
@@ -50,8 +50,8 @@ void main() async {
           print("Binary value: ${msg.value}");
         case TopicSubscriptionItemText():
           print("String value: ${msg.value}");
-        case TopicSubscriptionItemError():
-          print("Error receiving message: ${msg.errorCode}");
+        case TopicSubscriptionItemNotSet():
+          print("Value was not set");
       }
     }
   } catch (e) {

--- a/example/topics/advanced.dart
+++ b/example/topics/advanced.dart
@@ -50,8 +50,6 @@ void main() async {
           print("Binary value: ${msg.value}");
         case TopicSubscriptionItemText():
           print("String value: ${msg.value}");
-        case TopicSubscriptionItemNotSet():
-          print("Value was not set");
       }
     }
   } catch (e) {

--- a/example/topics/basic_subscriber.dart
+++ b/example/topics/basic_subscriber.dart
@@ -26,8 +26,8 @@ void main() async {
           print("Binary value: ${msg.value}");
         case TopicSubscriptionItemText():
           print("String value: ${msg.value}");
-        case TopicSubscriptionItemError():
-          print("Error receiving message: ${msg.errorCode}");
+        case TopicSubscriptionItemNotSet():
+          print("Value was not set");
       }
     }
   } catch (e) {

--- a/example/topics/basic_subscriber.dart
+++ b/example/topics/basic_subscriber.dart
@@ -26,8 +26,6 @@ void main() async {
           print("Binary value: ${msg.value}");
         case TopicSubscriptionItemText():
           print("String value: ${msg.value}");
-        case TopicSubscriptionItemNotSet():
-          print("Value was not set");
       }
     }
   } catch (e) {

--- a/lib/src/messages/responses/topics/topic_subscription_item.dart
+++ b/lib/src/messages/responses/topics/topic_subscription_item.dart
@@ -1,3 +1,4 @@
+import 'package:logging/logging.dart';
 import 'package:momento/generated/cachepubsub.pb.dart';
 
 sealed class TopicSubscriptionItemResponse {}
@@ -14,15 +15,15 @@ class TopicSubscriptionItemBinary implements TopicSubscriptionItemResponse {
   List<int> get value => _value;
 }
 
-class TopicSubscriptionItemNotSet implements TopicSubscriptionItemResponse {}
-
-TopicSubscriptionItemResponse createTopicItemResponse(TopicItem_ item) {
+TopicSubscriptionItemResponse? createTopicItemResponse(TopicItem_ item) {
+  final logger = Logger("TopicSubscriptionItemResponse");
   switch (item.value.whichKind()) {
     case TopicValue__Kind.text:
       return TopicSubscriptionItemText(item.value.text);
     case TopicValue__Kind.binary:
       return TopicSubscriptionItemBinary(item.value.binary);
     case TopicValue__Kind.notSet:
-      return TopicSubscriptionItemNotSet();
+      logger.fine("Received topic subscription item with no set value");
+      return null;
   }
 }

--- a/lib/src/messages/responses/topics/topic_subscription_item.dart
+++ b/lib/src/messages/responses/topics/topic_subscription_item.dart
@@ -1,6 +1,4 @@
 import 'package:momento/generated/cachepubsub.pb.dart';
-import 'package:momento/src/errors/errors.dart';
-import 'package:momento/src/messages/responses/responses_base.dart';
 
 sealed class TopicSubscriptionItemResponse {}
 
@@ -16,10 +14,7 @@ class TopicSubscriptionItemBinary implements TopicSubscriptionItemResponse {
   List<int> get value => _value;
 }
 
-class TopicSubscriptionItemError extends ErrorResponseBase
-    implements TopicSubscriptionItemResponse {
-  TopicSubscriptionItemError(super.exception);
-}
+class TopicSubscriptionItemNotSet implements TopicSubscriptionItemResponse {}
 
 TopicSubscriptionItemResponse createTopicItemResponse(TopicItem_ item) {
   switch (item.value.whichKind()) {
@@ -27,8 +22,7 @@ TopicSubscriptionItemResponse createTopicItemResponse(TopicItem_ item) {
       return TopicSubscriptionItemText(item.value.text);
     case TopicValue__Kind.binary:
       return TopicSubscriptionItemBinary(item.value.binary);
-    default:
-      return TopicSubscriptionItemError(UnknownException(
-          "unknown TopicItemResponse value: ${item.value}", null, null));
+    case TopicValue__Kind.notSet:
+      return TopicSubscriptionItemNotSet();
   }
 }


### PR DESCRIPTION
addresses #72 

From the [Dart docs on async streams](https://dart.dev/tutorials/language/streams#error-events): "When reading a stream using **await for**, the error is thrown by the loop statement. This ends the loop, as well. You can catch the error using **try-catch**"

Looks like the correct way to handle errors thrown from async streams in Dart is to use try-catch. `TopicSubscriptionItem`s will return only `text` or `binary` items, not errors.