### PR TITLE
fix: rename config classes for better autocompletes

### DIFF
--- a/example/quickstart/quickstart.dart
+++ b/example/quickstart/quickstart.dart
@@ -3,7 +3,7 @@ import 'package:momento/momento.dart';
 Future<void> main() async {
   final cacheClient = CacheClient(
       CredentialProvider.fromEnvironmentVariable("MOMENTO_API_KEY"),
-      MobileCacheConfiguration.latest(),
+      CacheClientConfigurations.latest(),
       Duration(seconds: 30));
 
   final cacheName = "cache";

--- a/example/topics/advanced.dart
+++ b/example/topics/advanced.dart
@@ -12,7 +12,7 @@ void main() async {
 
   var topicClient = TopicClient(
       CredentialProvider.fromEnvironmentVariable("MOMENTO_API_KEY"),
-      MobileTopicConfiguration.latest());
+      TopicClientConfigurations.latest());
 
   // start publishing messages in 2 seconds
   Timer(const Duration(seconds: 2), () async {

--- a/example/topics/basic_publisher.dart
+++ b/example/topics/basic_publisher.dart
@@ -4,7 +4,7 @@ import 'package:momento/momento.dart';
 void main() async {
   var topicClient = TopicClient(
       CredentialProvider.fromEnvironmentVariable("MOMENTO_API_KEY"),
-      MobileTopicConfiguration.latest());
+      TopicClientConfigurations.latest());
 
   // publish 10 messages spaced 1 second apart
   for (final i in Iterable.generate(10)) {

--- a/example/topics/basic_subscriber.dart
+++ b/example/topics/basic_subscriber.dart
@@ -4,7 +4,7 @@ import 'package:momento/momento.dart';
 void main() async {
   var topicClient = TopicClient(
       CredentialProvider.fromEnvironmentVariable("MOMENTO_API_KEY"),
-      MobileTopicConfiguration.latest());
+      TopicClientConfigurations.latest());
 
   var subscription = topicClient.subscribe("cache", "topic");
   var messageStream = switch (subscription) {

--- a/lib/src/cache_client.dart
+++ b/lib/src/cache_client.dart
@@ -32,7 +32,7 @@ class CacheClient implements ICacheClient {
   final MomentoLogger _logger = MomentoLogger('MomentoCacheClient');
 
   CacheClient(CredentialProvider credentialProvider,
-      CacheConfiguration configuration, Duration defaultTtl) {
+      CacheClientConfiguration configuration, Duration defaultTtl) {
     _dataClient = DataClient(credentialProvider, configuration, defaultTtl);
     _controlClient = ControlClient(credentialProvider, configuration);
     _logger.setLevel(configuration.logLevel);

--- a/lib/src/config/cache_configuration.dart
+++ b/lib/src/config/cache_configuration.dart
@@ -3,45 +3,47 @@ import 'package:momento/src/config/transport/transport_strategy.dart';
 
 import '../../momento.dart';
 
-abstract interface class CacheConfiguration {
+abstract interface class CacheClientConfiguration {
   /// Configures low-level options for network interactions with the Momento service
   late TransportStrategy transportStrategy;
 
   /// Configures the verbosity of the client-side logger
   LogLevel logLevel;
 
-  /// Constructor for a CacheConfiguration
-  CacheConfiguration(this.transportStrategy, this.logLevel);
+  /// Constructor for a CacheClientConfiguration
+  CacheClientConfiguration(this.transportStrategy, this.logLevel);
 
   /// Copy constructor for overriding TransportStrategy
-  CacheConfiguration withTransportStrategy(TransportStrategy transportStrategy,
+  CacheClientConfiguration withTransportStrategy(
+      TransportStrategy transportStrategy,
       {LogLevel logLevel = LogLevel.info});
 
   /// Convenience copy constructor that updates the client-side
   /// timeout setting in the transport strategy
-  CacheConfiguration withDeadline(Duration deadline,
+  CacheClientConfiguration withDeadline(Duration deadline,
       {LogLevel logLevel = LogLevel.info});
 }
 
-class CacheClientConfiguration implements CacheConfiguration {
+class CacheConfiguration implements CacheClientConfiguration {
   @override
   late TransportStrategy transportStrategy;
 
   @override
   LogLevel logLevel;
 
-  CacheClientConfiguration(this.transportStrategy, this.logLevel);
+  CacheConfiguration(this.transportStrategy, this.logLevel);
 
   @override
-  CacheConfiguration withTransportStrategy(TransportStrategy transportStrategy,
+  CacheClientConfiguration withTransportStrategy(
+      TransportStrategy transportStrategy,
       {LogLevel logLevel = LogLevel.info}) {
-    return CacheClientConfiguration(transportStrategy, logLevel);
+    return CacheConfiguration(transportStrategy, logLevel);
   }
 
   @override
-  CacheConfiguration withDeadline(Duration deadline,
+  CacheClientConfiguration withDeadline(Duration deadline,
       {LogLevel logLevel = LogLevel.info}) {
-    return CacheClientConfiguration(
+    return CacheConfiguration(
         StaticTransportStrategy(StaticGrpcConfiguration(deadline)), logLevel);
   }
 }

--- a/lib/src/config/cache_configurations.dart
+++ b/lib/src/config/cache_configurations.dart
@@ -5,16 +5,13 @@ import '../../momento.dart';
 import 'cache_configuration.dart';
 
 /// Prebuilt configurations for Momento Cache clients
-abstract interface class CacheClientConfigurations {}
-
-/// Provides prebuilt configurations for the `CacheClient` on mobile platforms
-class MobileCacheConfiguration extends CacheClientConfigurations {
+class CacheClientConfigurations {
   static CacheClientConfiguration defaultConfig() {
     return latest();
   }
 
   static CacheClientConfiguration latest({LogLevel logLevel = LogLevel.info}) {
-    return CacheClientConfiguration(
+    return CacheConfiguration(
         StaticTransportStrategy(StaticGrpcConfiguration(Duration(seconds: 15))),
         logLevel);
   }

--- a/lib/src/config/cache_configurations.dart
+++ b/lib/src/config/cache_configurations.dart
@@ -6,10 +6,6 @@ import 'cache_configuration.dart';
 
 /// Prebuilt configurations for Momento Cache clients
 class CacheClientConfigurations {
-  static CacheClientConfiguration defaultConfig() {
-    return latest();
-  }
-
   static CacheClientConfiguration latest({LogLevel logLevel = LogLevel.info}) {
     return CacheConfiguration(
         StaticTransportStrategy(StaticGrpcConfiguration(Duration(seconds: 15))),

--- a/lib/src/config/topic_configuration.dart
+++ b/lib/src/config/topic_configuration.dart
@@ -3,48 +3,50 @@ import 'package:momento/src/config/logger.dart';
 import 'transport/grpc_configuration.dart';
 import 'transport/transport_strategy.dart';
 
-abstract interface class TopicConfiguration {
+abstract interface class TopicClientConfiguration {
   /// Configures low-level options for network interactions with the Momento service
   late TransportStrategy transportStrategy;
 
   /// Configures the verbosity of the client-side logger
   LogLevel logLevel;
 
-  /// Constructor for a TopicConfiguration
-  TopicConfiguration(this.transportStrategy, this.logLevel);
+  /// Constructor for a TopicClientConfiguration
+  TopicClientConfiguration(this.transportStrategy, this.logLevel);
 
   /// Copy constructor for overriding TransportStrategy
-  TopicConfiguration withTransportStrategy(TransportStrategy transportStrategy,
+  TopicClientConfiguration withTransportStrategy(
+      TransportStrategy transportStrategy,
       {LogLevel logLevel = LogLevel.info});
 
   /// Convenience copy constructor that updates the client-side
   /// timeout setting in the transport strategy
-  TopicConfiguration withDeadline(Duration deadline,
+  TopicClientConfiguration withDeadline(Duration deadline,
       {LogLevel logLevel = LogLevel.info});
 }
 
 /// Configuration options for Momento TopicClient.
 /// The easiest way to get a `TopicClientConfiguration` object is
 /// to use one of the prebuilt TopicClientConfigurations classes.
-class TopicClientConfiguration implements TopicConfiguration {
+class TopicConfiguration implements TopicClientConfiguration {
   @override
   late TransportStrategy transportStrategy;
 
   @override
   LogLevel logLevel;
 
-  TopicClientConfiguration(this.transportStrategy, this.logLevel);
+  TopicConfiguration(this.transportStrategy, this.logLevel);
 
   @override
-  TopicConfiguration withTransportStrategy(TransportStrategy transportStrategy,
+  TopicClientConfiguration withTransportStrategy(
+      TransportStrategy transportStrategy,
       {LogLevel logLevel = LogLevel.info}) {
-    return TopicClientConfiguration(transportStrategy, logLevel);
+    return TopicConfiguration(transportStrategy, logLevel);
   }
 
   @override
-  TopicConfiguration withDeadline(Duration deadline,
+  TopicClientConfiguration withDeadline(Duration deadline,
       {LogLevel logLevel = LogLevel.info}) {
-    return TopicClientConfiguration(
+    return TopicConfiguration(
         StaticTransportStrategy(StaticGrpcConfiguration(deadline)), logLevel);
   }
 }

--- a/lib/src/config/topic_configurations.dart
+++ b/lib/src/config/topic_configurations.dart
@@ -4,16 +4,13 @@ import 'transport/grpc_configuration.dart';
 import 'transport/transport_strategy.dart';
 
 /// Prebuilt configurations for Momento Topics clients
-abstract interface class TopicClientConfigurations {}
-
-/// Provides prebuilt configurations for the `TopicClient` on mobile platforms
-class MobileTopicConfiguration extends TopicClientConfigurations {
+class TopicClientConfigurations {
   static TopicClientConfiguration defaultConfig() {
     return latest();
   }
 
   static TopicClientConfiguration latest({LogLevel logLevel = LogLevel.info}) {
-    return TopicClientConfiguration(
+    return TopicConfiguration(
         StaticTransportStrategy(StaticGrpcConfiguration(Duration(seconds: 15))),
         logLevel);
   }

--- a/lib/src/config/topic_configurations.dart
+++ b/lib/src/config/topic_configurations.dart
@@ -5,10 +5,6 @@ import 'transport/transport_strategy.dart';
 
 /// Prebuilt configurations for Momento Topics clients
 class TopicClientConfigurations {
-  static TopicClientConfiguration defaultConfig() {
-    return latest();
-  }
-
   static TopicClientConfiguration latest({LogLevel logLevel = LogLevel.info}) {
     return TopicConfiguration(
         StaticTransportStrategy(StaticGrpcConfiguration(Duration(seconds: 15))),

--- a/lib/src/internal/control_client.dart
+++ b/lib/src/internal/control_client.dart
@@ -17,7 +17,7 @@ abstract class AbstractControlClient {
 class ControlClient implements AbstractControlClient {
   late ClientChannel _channel;
   late ScsControlClient _client;
-  final CacheConfiguration _configuration;
+  final CacheClientConfiguration _configuration;
 
   ControlClient(CredentialProvider credentialProvider, this._configuration) {
     _channel = ClientChannel(credentialProvider.controlEndpoint);

--- a/lib/src/internal/data_client.dart
+++ b/lib/src/internal/data_client.dart
@@ -19,7 +19,7 @@ abstract class AbstractDataClient {
 class DataClient implements AbstractDataClient {
   late ClientChannel _channel;
   late ScsClient _client;
-  final CacheConfiguration _configuration;
+  final CacheClientConfiguration _configuration;
   final Duration _defaultTtl;
 
   DataClient(CredentialProvider credentialProvider, this._configuration,

--- a/lib/src/internal/pubsub_client.dart
+++ b/lib/src/internal/pubsub_client.dart
@@ -20,7 +20,7 @@ abstract class AbstractPubsubClient {
 }
 
 class ClientPubsub implements AbstractPubsubClient {
-  final TopicConfiguration _configuration;
+  final TopicClientConfiguration _configuration;
   late final TopicGrpcManager _grpcManager;
 
   ClientPubsub(CredentialProvider credentialProvider, this._configuration) {

--- a/lib/src/topic_client.dart
+++ b/lib/src/topic_client.dart
@@ -19,8 +19,8 @@ class TopicClient implements ITopicClient {
   final ClientPubsub _pubsubClient;
   final MomentoLogger _logger = MomentoLogger('MomentoTopicClient');
 
-  TopicClient(
-      CredentialProvider credentialProvider, TopicConfiguration configuration)
+  TopicClient(CredentialProvider credentialProvider,
+      TopicClientConfiguration configuration)
       : _pubsubClient = ClientPubsub(credentialProvider, configuration) {
     _logger.setLevel(configuration.logLevel);
     _logger.trace("initializing topic client");

--- a/test/src/cache/test_utils.dart
+++ b/test/src/cache/test_utils.dart
@@ -14,7 +14,7 @@ class TestSetup {
 Future<TestSetup> setUpIntegrationTests() async {
   final cacheClient = CacheClient(
       CredentialProvider.fromEnvironmentVariable(apiKeyEnvVarName),
-      MobileCacheConfiguration.latest(),
+      CacheClientConfigurations.latest(),
       Duration(seconds: 30));
   final integrationTestCacheName =
       generateStringWithUuid("dart-sdk-cache-tests");


### PR DESCRIPTION
addresses #76 

meant to make autocompleting the creation of a CacheClient or TopicClient easier. The name of the abstract config class is now `CacheClientConfiguration` and the name of the class with static methods that return prebuilt configs is `CacheClientConfigurations`. Also removed the `defaultConfig` option and just kept `latest` for consistency with the other SDKs