### PR TITLE
chore: provide informational error message when api key env var is not set

### DIFF
--- a/lib/src/auth/credential_provider.dart
+++ b/lib/src/auth/credential_provider.dart
@@ -17,7 +17,7 @@ class CredentialProviderError {
   }
 
   static String emptyEnvironmentVariable(String envVarName) {
-    return "Could not find environment variable $envVarName or the variable was an empty string";
+    return "Environment variable $envVarName is required and not set";
   }
 }
 


### PR DESCRIPTION
addresses #77 

Before:
```
Unhandled exception:
API key is an empty string
```

After: 
```
Unhandled exception:
Environment variable MOMENTO_API_KEY is required and not set
```