### PR TITLE
chore: readme template was missing code block markdown for usage section

### DIFF
--- a/README.template.md
+++ b/README.template.md
@@ -31,7 +31,9 @@ Check out our [example](./example/) directory for complete examples of using the
 
 Here is a quickstart you can use for your own project:
 
+```dart
 {% include "./example/quickstart/quickstart.dart" %}
+```
 
 ## Getting Started and Documentation
 


### PR DESCRIPTION
Usage section of the generated readme was missing the code block formatting