### PR TITLE
chore: error responses should print informative errors by default

### DIFF
--- a/lib/src/messages/responses/responses_base.dart
+++ b/lib/src/messages/responses/responses_base.dart
@@ -1,6 +1,12 @@
 import '../../errors/errors.dart';
 
-class ErrorResponseBase extends AbstractExceptionResponseBase {
+class ErrorResponseBase extends AbstractExceptionResponseBase
+    implements Exception {
   ErrorResponseBase(SdkException exception)
       : super(exception.message, exception.errorCode, exception.innerException);
+
+  @override
+  String toString() {
+    return "[${super.errorCode}] ${super.message}";
+  }
 }

--- a/test/src/cache/topics_test.dart
+++ b/test/src/cache/topics_test.dart
@@ -79,7 +79,7 @@ void main() {
               'Expected Success but got Error: ${subscribeResp.errorCode} ${subscribeResp.message}');
       }
 
-      sleep(Duration(seconds: 1));
+      sleep(Duration(seconds: 5));
       final publishResp = await topicClient.publish(
           integrationTestCacheName, topicName, StringValue(topicValue));
       switch (publishResp) {
@@ -90,7 +90,7 @@ void main() {
           fail(
               'Expected Success but got Error: ${publishResp.errorCode} ${publishResp.message}');
       }
-      sleep(Duration(seconds: 1));
+      sleep(Duration(seconds: 5));
 
       try {
         await for (final msg in subscribeResp.stream) {


### PR DESCRIPTION
addresses #88

Before, `print(getResp)` would print `Instance of 'GetError'` and now it’ll print `[MomentoErrorCode.invalidArgumentError] Invalid cache name`

Makes use of Dart's Exception class which has a `toString` method that's used to print exceptions.