### PR TITLE
chore: implement toString for non-error response classes

### DIFF
--- a/lib/src/internal/control_client.dart
+++ b/lib/src/internal/control_client.dart
@@ -37,10 +37,10 @@ class ControlClient implements AbstractControlClient {
           options: CallOptions(metadata: {
             'cache': cacheName,
           }));
-      return CreateCacheSuccess();
+      return CreateCacheSuccess(message: "Created cache '$cacheName'");
     } catch (e) {
       if (e is GrpcError && e.code == StatusCode.alreadyExists) {
-        return AlreadyExists();
+        return AlreadyExists(message: "Cache '$cacheName' already exists");
       } else if (e is GrpcError) {
         return CreateCacheError(grpcStatusToSdkException(e));
       } else {
@@ -59,7 +59,7 @@ class ControlClient implements AbstractControlClient {
           options: CallOptions(metadata: {
             'cache': cacheName,
           }));
-      return DeleteCacheSuccess();
+      return DeleteCacheSuccess(message: "Deleted cache '$cacheName'");
     } catch (e) {
       if (e is GrpcError) {
         return DeleteCacheError(grpcStatusToSdkException(e));
@@ -75,7 +75,8 @@ class ControlClient implements AbstractControlClient {
     var request = ListCachesRequest_();
     try {
       final resp = await _client.listCaches(request);
-      return ListCachesSuccess(resp.cache);
+      return ListCachesSuccess(resp.cache,
+          message: "Successfully fetched all caches in account");
     } catch (e) {
       if (e is GrpcError) {
         return ListCachesError(grpcStatusToSdkException(e));

--- a/lib/src/internal/control_client.dart
+++ b/lib/src/internal/control_client.dart
@@ -75,8 +75,7 @@ class ControlClient implements AbstractControlClient {
     var request = ListCachesRequest_();
     try {
       final resp = await _client.listCaches(request);
-      return ListCachesSuccess(resp.cache,
-          message: "Successfully fetched all caches in account");
+      return ListCachesSuccess(resp.cache);
     } catch (e) {
       if (e is GrpcError) {
         return ListCachesError(grpcStatusToSdkException(e));

--- a/lib/src/internal/control_client.dart
+++ b/lib/src/internal/control_client.dart
@@ -37,10 +37,10 @@ class ControlClient implements AbstractControlClient {
           options: CallOptions(metadata: {
             'cache': cacheName,
           }));
-      return CreateCacheSuccess(message: "Created cache '$cacheName'");
+      return CreateCacheSuccess();
     } catch (e) {
       if (e is GrpcError && e.code == StatusCode.alreadyExists) {
-        return AlreadyExists(message: "Cache '$cacheName' already exists");
+        return AlreadyExists();
       } else if (e is GrpcError) {
         return CreateCacheError(grpcStatusToSdkException(e));
       } else {
@@ -59,7 +59,7 @@ class ControlClient implements AbstractControlClient {
           options: CallOptions(metadata: {
             'cache': cacheName,
           }));
-      return DeleteCacheSuccess(message: "Deleted cache '$cacheName'");
+      return DeleteCacheSuccess();
     } catch (e) {
       if (e is GrpcError) {
         return DeleteCacheError(grpcStatusToSdkException(e));

--- a/lib/src/internal/data_client.dart
+++ b/lib/src/internal/data_client.dart
@@ -75,9 +75,11 @@ class DataClient implements AbstractDataClient {
 
       switch (resp.result) {
         case ECacheResult.Miss:
-          return GetMiss();
+          return GetMiss(
+              message: "Miss for key '${key.toUtf8()}' in cache '$cacheName'");
         case ECacheResult.Hit:
-          return GetHit(resp.cacheBody);
+          return GetHit(resp.cacheBody,
+              message: "Hit for key '${key.toUtf8()}' in cache '$cacheName'");
         default:
           return GetError(UnknownException(
               "unknown cache get error ${resp.result}", null, null));
@@ -104,7 +106,9 @@ class DataClient implements AbstractDataClient {
           options: CallOptions(metadata: {
             'cache': cacheName,
           }));
-      return SetSuccess();
+      return SetSuccess(
+          message:
+              "Successfully set key '${key.toUtf8()}' and value '${value.toUtf8()}' in cache '$cacheName'");
     } catch (e) {
       if (e is GrpcError) {
         return SetError(grpcStatusToSdkException(e));
@@ -123,7 +127,9 @@ class DataClient implements AbstractDataClient {
           options: CallOptions(metadata: {
             'cache': cacheName,
           }));
-      return DeleteSuccess();
+      return DeleteSuccess(
+          message:
+              "Successfully deleted key '${key.toUtf8()}' in cache '$cacheName'");
     } catch (e) {
       if (e is GrpcError) {
         return DeleteError(grpcStatusToSdkException(e));
@@ -151,7 +157,9 @@ class DataClient implements AbstractDataClient {
           options: CallOptions(metadata: {
             'cache': cacheName,
           }));
-      return ListConcatenateBackSuccess(response.listLength);
+      return ListConcatenateBackSuccess(response.listLength,
+          message:
+              "Concatenated ${values.length} values to back of list '$listName' in cache '$cacheName'");
     } catch (e) {
       if (e is GrpcError) {
         return ListConcatenateBackError(grpcStatusToSdkException(e));
@@ -179,7 +187,9 @@ class DataClient implements AbstractDataClient {
           options: CallOptions(metadata: {
             'cache': cacheName,
           }));
-      return ListConcatenateFrontSuccess(response.listLength);
+      return ListConcatenateFrontSuccess(response.listLength,
+          message:
+              "Concatenated ${values.length} values to front of list '$listName' in cache '$cacheName'");
     } catch (e) {
       if (e is GrpcError) {
         return ListConcatenateFrontError(grpcStatusToSdkException(e));
@@ -213,9 +223,11 @@ class DataClient implements AbstractDataClient {
           }));
       switch (response.whichList()) {
         case ListFetchResponse__List.found:
-          return ListFetchHit(response.found.values);
+          return ListFetchHit(response.found.values,
+              message: "Found list '$listName' in cache '$cacheName'");
         case ListFetchResponse__List.missing:
-          return ListFetchMiss();
+          return ListFetchMiss(
+              message: "List '$listName' not found in cache '$cacheName'");
         default:
           return ListFetchError(
               UnknownException("Unexpected error: $response", null, null));
@@ -242,9 +254,12 @@ class DataClient implements AbstractDataClient {
           }));
       switch (response.whichList()) {
         case ListLengthResponse__List.found:
-          return ListLengthHit(response.found.length);
+          return ListLengthHit(response.found.length,
+              message:
+                  "List '$listName' in cache '$cacheName' has length ${response.found.length}");
         case ListLengthResponse__List.missing:
-          return ListLengthMiss();
+          return ListLengthMiss(
+              message: "List '$listName' not found in cache '$cacheName'");
         default:
           return ListLengthError(
               UnknownException("Unexpected error: $response", null, null));
@@ -271,9 +286,12 @@ class DataClient implements AbstractDataClient {
           }));
       switch (response.whichList()) {
         case ListPopBackResponse__List.found:
-          return ListPopBackHit(response.found.back);
+          return ListPopBackHit(response.found.back,
+              message:
+                  "Popped back value '${response.found.back}' from list '$listName' in cache '$cacheName'");
         case ListPopBackResponse__List.missing:
-          return ListPopBackMiss();
+          return ListPopBackMiss(
+              message: "List '$listName' not found in cache '$cacheName'");
         default:
           return ListPopBackError(
               UnknownException("Unexpected error: $response", null, null));
@@ -300,9 +318,12 @@ class DataClient implements AbstractDataClient {
           }));
       switch (response.whichList()) {
         case ListPopFrontResponse__List.found:
-          return ListPopFrontHit(response.found.front);
+          return ListPopFrontHit(response.found.front,
+              message:
+                  "Popped front value '${response.found.front}' from list '$listName' in cache '$cacheName'");
         case ListPopFrontResponse__List.missing:
-          return ListPopFrontMiss();
+          return ListPopFrontMiss(
+              message: "List '$listName' not found in cache '$cacheName'");
         default:
           return ListPopFrontError(
               UnknownException("Unexpected error: $response", null, null));
@@ -334,7 +355,9 @@ class DataClient implements AbstractDataClient {
           options: CallOptions(metadata: {
             'cache': cacheName,
           }));
-      return ListPushBackSuccess(response.listLength);
+      return ListPushBackSuccess(response.listLength,
+          message:
+              "Pushed value '${value.toUtf8()}' to back of list '$listName' in cache '$cacheName'");
     } catch (e) {
       if (e is GrpcError) {
         return ListPushBackError(grpcStatusToSdkException(e));
@@ -362,7 +385,9 @@ class DataClient implements AbstractDataClient {
           options: CallOptions(metadata: {
             'cache': cacheName,
           }));
-      return ListPushFrontSuccess(response.listLength);
+      return ListPushFrontSuccess(response.listLength,
+          message:
+              "Pushed value '${value.toUtf8()}' to front of list '$listName' in cache '$cacheName'");
     } catch (e) {
       if (e is GrpcError) {
         return ListPushFrontError(grpcStatusToSdkException(e));
@@ -384,7 +409,9 @@ class DataClient implements AbstractDataClient {
           options: CallOptions(metadata: {
             'cache': cacheName,
           }));
-      return ListRemoveValueSuccess();
+      return ListRemoveValueSuccess(
+          message:
+              "Removed all instances of value '${value.toUtf8()}' from list '$listName' in cache '$cacheName'");
     } catch (e) {
       if (e is GrpcError) {
         return ListRemoveValueError(grpcStatusToSdkException(e));
@@ -419,7 +446,9 @@ class DataClient implements AbstractDataClient {
           options: CallOptions(metadata: {
             'cache': cacheName,
           }));
-      return ListRetainSuccess();
+      return ListRetainSuccess(
+          message:
+              "Retained values in list '$listName' in cache '$cacheName' with startIndex '${startIndex ?? 'unbounded'}' and endIndex '${endIndex ?? 'unbounded'}'");
     } catch (e) {
       if (e is GrpcError) {
         return ListRetainError(grpcStatusToSdkException(e));

--- a/lib/src/internal/data_client.dart
+++ b/lib/src/internal/data_client.dart
@@ -75,11 +75,9 @@ class DataClient implements AbstractDataClient {
 
       switch (resp.result) {
         case ECacheResult.Miss:
-          return GetMiss(
-              message: "Miss for key '${key.toUtf8()}' in cache '$cacheName'");
+          return GetMiss();
         case ECacheResult.Hit:
-          return GetHit(resp.cacheBody,
-              message: "Hit for key '${key.toUtf8()}' in cache '$cacheName'");
+          return GetHit(resp.cacheBody);
         default:
           return GetError(UnknownException(
               "unknown cache get error ${resp.result}", null, null));
@@ -106,9 +104,7 @@ class DataClient implements AbstractDataClient {
           options: CallOptions(metadata: {
             'cache': cacheName,
           }));
-      return SetSuccess(
-          message:
-              "Successfully set key '${key.toUtf8()}' and value '${value.toUtf8()}' in cache '$cacheName'");
+      return SetSuccess();
     } catch (e) {
       if (e is GrpcError) {
         return SetError(grpcStatusToSdkException(e));
@@ -127,9 +123,7 @@ class DataClient implements AbstractDataClient {
           options: CallOptions(metadata: {
             'cache': cacheName,
           }));
-      return DeleteSuccess(
-          message:
-              "Successfully deleted key '${key.toUtf8()}' in cache '$cacheName'");
+      return DeleteSuccess();
     } catch (e) {
       if (e is GrpcError) {
         return DeleteError(grpcStatusToSdkException(e));
@@ -157,9 +151,7 @@ class DataClient implements AbstractDataClient {
           options: CallOptions(metadata: {
             'cache': cacheName,
           }));
-      return ListConcatenateBackSuccess(response.listLength,
-          message:
-              "Concatenated ${values.length} values to back of list '$listName' in cache '$cacheName'");
+      return ListConcatenateBackSuccess(response.listLength);
     } catch (e) {
       if (e is GrpcError) {
         return ListConcatenateBackError(grpcStatusToSdkException(e));
@@ -187,9 +179,7 @@ class DataClient implements AbstractDataClient {
           options: CallOptions(metadata: {
             'cache': cacheName,
           }));
-      return ListConcatenateFrontSuccess(response.listLength,
-          message:
-              "Concatenated ${values.length} values to front of list '$listName' in cache '$cacheName'");
+      return ListConcatenateFrontSuccess(response.listLength,);
     } catch (e) {
       if (e is GrpcError) {
         return ListConcatenateFrontError(grpcStatusToSdkException(e));
@@ -223,11 +213,9 @@ class DataClient implements AbstractDataClient {
           }));
       switch (response.whichList()) {
         case ListFetchResponse__List.found:
-          return ListFetchHit(response.found.values,
-              message: "Found list '$listName' in cache '$cacheName'");
+          return ListFetchHit(response.found.values);
         case ListFetchResponse__List.missing:
-          return ListFetchMiss(
-              message: "List '$listName' not found in cache '$cacheName'");
+          return ListFetchMiss();
         default:
           return ListFetchError(
               UnknownException("Unexpected error: $response", null, null));
@@ -254,12 +242,9 @@ class DataClient implements AbstractDataClient {
           }));
       switch (response.whichList()) {
         case ListLengthResponse__List.found:
-          return ListLengthHit(response.found.length,
-              message:
-                  "List '$listName' in cache '$cacheName' has length ${response.found.length}");
+          return ListLengthHit(response.found.length);
         case ListLengthResponse__List.missing:
-          return ListLengthMiss(
-              message: "List '$listName' not found in cache '$cacheName'");
+          return ListLengthMiss();
         default:
           return ListLengthError(
               UnknownException("Unexpected error: $response", null, null));
@@ -286,12 +271,9 @@ class DataClient implements AbstractDataClient {
           }));
       switch (response.whichList()) {
         case ListPopBackResponse__List.found:
-          return ListPopBackHit(response.found.back,
-              message:
-                  "Popped back value '${response.found.back}' from list '$listName' in cache '$cacheName'");
+          return ListPopBackHit(response.found.back,);
         case ListPopBackResponse__List.missing:
-          return ListPopBackMiss(
-              message: "List '$listName' not found in cache '$cacheName'");
+          return ListPopBackMiss();
         default:
           return ListPopBackError(
               UnknownException("Unexpected error: $response", null, null));
@@ -318,12 +300,9 @@ class DataClient implements AbstractDataClient {
           }));
       switch (response.whichList()) {
         case ListPopFrontResponse__List.found:
-          return ListPopFrontHit(response.found.front,
-              message:
-                  "Popped front value '${response.found.front}' from list '$listName' in cache '$cacheName'");
+          return ListPopFrontHit(response.found.front);
         case ListPopFrontResponse__List.missing:
-          return ListPopFrontMiss(
-              message: "List '$listName' not found in cache '$cacheName'");
+          return ListPopFrontMiss();
         default:
           return ListPopFrontError(
               UnknownException("Unexpected error: $response", null, null));
@@ -355,9 +334,7 @@ class DataClient implements AbstractDataClient {
           options: CallOptions(metadata: {
             'cache': cacheName,
           }));
-      return ListPushBackSuccess(response.listLength,
-          message:
-              "Pushed value '${value.toUtf8()}' to back of list '$listName' in cache '$cacheName'");
+      return ListPushBackSuccess(response.listLength);
     } catch (e) {
       if (e is GrpcError) {
         return ListPushBackError(grpcStatusToSdkException(e));
@@ -385,9 +362,7 @@ class DataClient implements AbstractDataClient {
           options: CallOptions(metadata: {
             'cache': cacheName,
           }));
-      return ListPushFrontSuccess(response.listLength,
-          message:
-              "Pushed value '${value.toUtf8()}' to front of list '$listName' in cache '$cacheName'");
+      return ListPushFrontSuccess(response.listLength);
     } catch (e) {
       if (e is GrpcError) {
         return ListPushFrontError(grpcStatusToSdkException(e));
@@ -409,9 +384,7 @@ class DataClient implements AbstractDataClient {
           options: CallOptions(metadata: {
             'cache': cacheName,
           }));
-      return ListRemoveValueSuccess(
-          message:
-              "Removed all instances of value '${value.toUtf8()}' from list '$listName' in cache '$cacheName'");
+      return ListRemoveValueSuccess();
     } catch (e) {
       if (e is GrpcError) {
         return ListRemoveValueError(grpcStatusToSdkException(e));
@@ -446,9 +419,7 @@ class DataClient implements AbstractDataClient {
           options: CallOptions(metadata: {
             'cache': cacheName,
           }));
-      return ListRetainSuccess(
-          message:
-              "Retained values in list '$listName' in cache '$cacheName' with startIndex '${startIndex ?? 'unbounded'}' and endIndex '${endIndex ?? 'unbounded'}'");
+      return ListRetainSuccess();
     } catch (e) {
       if (e is GrpcError) {
         return ListRetainError(grpcStatusToSdkException(e));

--- a/lib/src/internal/data_client.dart
+++ b/lib/src/internal/data_client.dart
@@ -179,7 +179,9 @@ class DataClient implements AbstractDataClient {
           options: CallOptions(metadata: {
             'cache': cacheName,
           }));
-      return ListConcatenateFrontSuccess(response.listLength,);
+      return ListConcatenateFrontSuccess(
+        response.listLength,
+      );
     } catch (e) {
       if (e is GrpcError) {
         return ListConcatenateFrontError(grpcStatusToSdkException(e));
@@ -271,7 +273,9 @@ class DataClient implements AbstractDataClient {
           }));
       switch (response.whichList()) {
         case ListPopBackResponse__List.found:
-          return ListPopBackHit(response.found.back,);
+          return ListPopBackHit(
+            response.found.back,
+          );
         case ListPopBackResponse__List.missing:
           return ListPopBackMiss();
         default:

--- a/lib/src/internal/pubsub_client.dart
+++ b/lib/src/internal/pubsub_client.dart
@@ -50,9 +50,7 @@ class ClientPubsub implements AbstractPubsubClient {
       await _grpcManager.client.publish(request,
           options: CallOptions(
               timeout: _configuration.transportStrategy.grpcConfig.deadline));
-      return TopicPublishSuccess(
-          message:
-              "Published value '${value.toUtf8()}' to topic '$topicName' in cache '$cacheName'");
+      return TopicPublishSuccess();
     } catch (e) {
       if (e is GrpcError) {
         return TopicPublishError(grpcStatusToSdkException(e));

--- a/lib/src/internal/pubsub_client.dart
+++ b/lib/src/internal/pubsub_client.dart
@@ -50,7 +50,9 @@ class ClientPubsub implements AbstractPubsubClient {
       await _grpcManager.client.publish(request,
           options: CallOptions(
               timeout: _configuration.transportStrategy.grpcConfig.deadline));
-      return TopicPublishSuccess();
+      return TopicPublishSuccess(
+          message:
+              "Published value '${value.toUtf8()}' to topic '$topicName' in cache '$cacheName'");
     } catch (e) {
       if (e is GrpcError) {
         return TopicPublishError(grpcStatusToSdkException(e));

--- a/lib/src/internal/utils/display.dart
+++ b/lib/src/internal/utils/display.dart
@@ -1,0 +1,27 @@
+const displaySizeLimit = 5;
+
+String truncateString(String value, {int maxLength = 32}) {
+  if (value.length > maxLength) {
+    return '${value.substring(0, maxLength)}...';
+  } else {
+    return value;
+  }
+}
+
+List<String> truncateStringArrayToSize(List<String> stringArray,
+    {int length = displaySizeLimit}) {
+  if (stringArray.length <= length) {
+    return stringArray;
+  } else {
+    return stringArray.sublist(0, length).followedBy(['...']).toList();
+  }
+}
+
+List<String> truncateStringArray(List<String> stringArray,
+    {int length = displaySizeLimit}) {
+  final truncatedStringArray =
+      truncateStringArrayToSize(stringArray, length: length);
+  return truncatedStringArray.map((s) {
+    return truncateString(s);
+  }).toList();
+}

--- a/lib/src/messages/responses/cache/control/create_cache_response.dart
+++ b/lib/src/messages/responses/cache/control/create_cache_response.dart
@@ -16,10 +16,15 @@ import 'package:momento/src/messages/responses/responses_base.dart';
 sealed class CreateCacheResponse {}
 
 /// Indicates a successful create cache request.
-class CreateCacheSuccess implements CreateCacheResponse {}
+class CreateCacheSuccess extends NonErroResponseBase
+    implements CreateCacheResponse {
+  CreateCacheSuccess({String message = "CreateCacheSuccess"}) : super(message);
+}
 
 /// Indicates that the cache already exists, so there was nothing to do.
-class AlreadyExists implements CreateCacheResponse {}
+class AlreadyExists extends NonErroResponseBase implements CreateCacheResponse {
+  AlreadyExists({String message = "AlreadyExists"}) : super(message);
+}
 
 /// Indicates that an error occurred during the create cache request.
 ///

--- a/lib/src/messages/responses/cache/control/create_cache_response.dart
+++ b/lib/src/messages/responses/cache/control/create_cache_response.dart
@@ -16,11 +16,11 @@ import 'package:momento/src/messages/responses/responses_base.dart';
 sealed class CreateCacheResponse {}
 
 /// Indicates a successful create cache request.
-class CreateCacheSuccess extends NonErroResponseBase
+class CreateCacheSuccess extends NonErrorResponseBase
     implements CreateCacheResponse {}
 
 /// Indicates that the cache already exists, so there was nothing to do.
-class AlreadyExists extends NonErroResponseBase
+class AlreadyExists extends NonErrorResponseBase
     implements CreateCacheResponse {}
 
 /// Indicates that an error occurred during the create cache request.

--- a/lib/src/messages/responses/cache/control/create_cache_response.dart
+++ b/lib/src/messages/responses/cache/control/create_cache_response.dart
@@ -16,12 +16,10 @@ import 'package:momento/src/messages/responses/responses_base.dart';
 sealed class CreateCacheResponse {}
 
 /// Indicates a successful create cache request.
-class CreateCacheSuccess extends NonErrorResponseBase
-    implements CreateCacheResponse {}
+class CreateCacheSuccess extends ResponseBase implements CreateCacheResponse {}
 
 /// Indicates that the cache already exists, so there was nothing to do.
-class AlreadyExists extends NonErrorResponseBase
-    implements CreateCacheResponse {}
+class AlreadyExists extends ResponseBase implements CreateCacheResponse {}
 
 /// Indicates that an error occurred during the create cache request.
 ///

--- a/lib/src/messages/responses/cache/control/create_cache_response.dart
+++ b/lib/src/messages/responses/cache/control/create_cache_response.dart
@@ -17,14 +17,10 @@ sealed class CreateCacheResponse {}
 
 /// Indicates a successful create cache request.
 class CreateCacheSuccess extends NonErroResponseBase
-    implements CreateCacheResponse {
-  CreateCacheSuccess({String message = "CreateCacheSuccess"}) : super(message);
-}
+    implements CreateCacheResponse {}
 
 /// Indicates that the cache already exists, so there was nothing to do.
-class AlreadyExists extends NonErroResponseBase implements CreateCacheResponse {
-  AlreadyExists({String message = "AlreadyExists"}) : super(message);
-}
+class AlreadyExists extends NonErroResponseBase implements CreateCacheResponse {}
 
 /// Indicates that an error occurred during the create cache request.
 ///

--- a/lib/src/messages/responses/cache/control/create_cache_response.dart
+++ b/lib/src/messages/responses/cache/control/create_cache_response.dart
@@ -20,7 +20,8 @@ class CreateCacheSuccess extends NonErroResponseBase
     implements CreateCacheResponse {}
 
 /// Indicates that the cache already exists, so there was nothing to do.
-class AlreadyExists extends NonErroResponseBase implements CreateCacheResponse {}
+class AlreadyExists extends NonErroResponseBase
+    implements CreateCacheResponse {}
 
 /// Indicates that an error occurred during the create cache request.
 ///

--- a/lib/src/messages/responses/cache/control/create_cache_response.dart
+++ b/lib/src/messages/responses/cache/control/create_cache_response.dart
@@ -19,7 +19,8 @@ sealed class CreateCacheResponse {}
 class CreateCacheSuccess extends ResponseBase implements CreateCacheResponse {}
 
 /// Indicates that the cache already exists, so there was nothing to do.
-class CreateCacheAlreadyExists extends ResponseBase implements CreateCacheResponse {}
+class CreateCacheAlreadyExists extends ResponseBase
+    implements CreateCacheResponse {}
 
 /// Indicates that an error occurred during the create cache request.
 ///

--- a/lib/src/messages/responses/cache/control/delete_cache_response.dart
+++ b/lib/src/messages/responses/cache/control/delete_cache_response.dart
@@ -14,7 +14,7 @@ import 'package:momento/src/messages/responses/responses_base.dart';
 sealed class DeleteCacheResponse {}
 
 /// Indicates a successful delete cache request.
-class DeleteCacheSuccess extends NonErroResponseBase
+class DeleteCacheSuccess extends NonErrorResponseBase
     implements DeleteCacheResponse {}
 
 /// Indicates that an error occurred during the delete cache request.

--- a/lib/src/messages/responses/cache/control/delete_cache_response.dart
+++ b/lib/src/messages/responses/cache/control/delete_cache_response.dart
@@ -14,8 +14,7 @@ import 'package:momento/src/messages/responses/responses_base.dart';
 sealed class DeleteCacheResponse {}
 
 /// Indicates a successful delete cache request.
-class DeleteCacheSuccess extends NonErrorResponseBase
-    implements DeleteCacheResponse {}
+class DeleteCacheSuccess extends ResponseBase implements DeleteCacheResponse {}
 
 /// Indicates that an error occurred during the delete cache request.
 ///

--- a/lib/src/messages/responses/cache/control/delete_cache_response.dart
+++ b/lib/src/messages/responses/cache/control/delete_cache_response.dart
@@ -15,9 +15,7 @@ sealed class DeleteCacheResponse {}
 
 /// Indicates a successful delete cache request.
 class DeleteCacheSuccess extends NonErroResponseBase
-    implements DeleteCacheResponse {
-  DeleteCacheSuccess({String message = "DeleteCacheSuccess"}) : super(message);
-}
+    implements DeleteCacheResponse {}
 
 /// Indicates that an error occurred during the delete cache request.
 ///

--- a/lib/src/messages/responses/cache/control/delete_cache_response.dart
+++ b/lib/src/messages/responses/cache/control/delete_cache_response.dart
@@ -14,7 +14,10 @@ import 'package:momento/src/messages/responses/responses_base.dart';
 sealed class DeleteCacheResponse {}
 
 /// Indicates a successful delete cache request.
-class DeleteCacheSuccess implements DeleteCacheResponse {}
+class DeleteCacheSuccess extends NonErroResponseBase
+    implements DeleteCacheResponse {
+  DeleteCacheSuccess({String message = "DeleteCacheSuccess"}) : super(message);
+}
 
 /// Indicates that an error occurred during the delete cache request.
 ///

--- a/lib/src/messages/responses/cache/control/list_caches_response.dart
+++ b/lib/src/messages/responses/cache/control/list_caches_response.dart
@@ -23,12 +23,11 @@ class CacheInfo {
 sealed class ListCachesResponse {}
 
 /// Indicates a successful list caches request.
-class ListCachesSuccess extends NonErroResponseBase
+class ListCachesSuccess extends NonErrorResponseBase
     implements ListCachesResponse {
   late final List<CacheInfo> caches;
 
-  ListCachesSuccess(List<Cache_> grpcCaches,
-      {String message = "ListCachesSuccess"}) {
+  ListCachesSuccess(List<Cache_> grpcCaches) {
     caches = grpcCaches.map((cache) => CacheInfo(cache.cacheName)).toList();
   }
 

--- a/lib/src/messages/responses/cache/control/list_caches_response.dart
+++ b/lib/src/messages/responses/cache/control/list_caches_response.dart
@@ -23,10 +23,13 @@ class CacheInfo {
 sealed class ListCachesResponse {}
 
 /// Indicates a successful list caches request.
-class ListCachesSuccess implements ListCachesResponse {
+class ListCachesSuccess extends NonErroResponseBase
+    implements ListCachesResponse {
   late final List<CacheInfo> caches;
 
-  ListCachesSuccess(List<Cache_> grpcCaches) {
+  ListCachesSuccess(List<Cache_> grpcCaches,
+      {String message = "ListCachesSuccess"})
+      : super(message) {
     caches = grpcCaches.map((cache) => CacheInfo(cache.cacheName)).toList();
   }
 

--- a/lib/src/messages/responses/cache/control/list_caches_response.dart
+++ b/lib/src/messages/responses/cache/control/list_caches_response.dart
@@ -23,8 +23,7 @@ class CacheInfo {
 sealed class ListCachesResponse {}
 
 /// Indicates a successful list caches request.
-class ListCachesSuccess extends NonErrorResponseBase
-    implements ListCachesResponse {
+class ListCachesSuccess extends ResponseBase implements ListCachesResponse {
   late final List<CacheInfo> caches;
 
   ListCachesSuccess(List<Cache_> grpcCaches) {

--- a/lib/src/messages/responses/cache/control/list_caches_response.dart
+++ b/lib/src/messages/responses/cache/control/list_caches_response.dart
@@ -28,8 +28,7 @@ class ListCachesSuccess extends NonErroResponseBase
   late final List<CacheInfo> caches;
 
   ListCachesSuccess(List<Cache_> grpcCaches,
-      {String message = "ListCachesSuccess"})
-      : super(message) {
+      {String message = "ListCachesSuccess"}) {
     caches = grpcCaches.map((cache) => CacheInfo(cache.cacheName)).toList();
   }
 
@@ -38,6 +37,11 @@ class ListCachesSuccess extends NonErroResponseBase
   }
 
   List<String> get cacheNames => caches.map((cache) => cache.name).toList();
+
+  @override
+  String toString() {
+    return "$runtimeType: $cacheNames";
+  }
 }
 
 /// Indicates that an error occurred during the list caches request.

--- a/lib/src/messages/responses/cache/control/list_caches_response.dart
+++ b/lib/src/messages/responses/cache/control/list_caches_response.dart
@@ -1,4 +1,5 @@
 import 'package:momento/generated/controlclient.pb.dart';
+import 'package:momento/src/internal/utils/display.dart';
 import 'package:momento/src/messages/responses/responses_base.dart';
 
 /// Represents information about a listed cache, such as its name.
@@ -38,7 +39,7 @@ class ListCachesSuccess extends ResponseBase implements ListCachesResponse {
 
   @override
   String toString() {
-    return "$runtimeType: $cacheNames";
+    return "${super.toString()}: ${truncateStringArray(cacheNames)}";
   }
 }
 

--- a/lib/src/messages/responses/cache/data/list/list_concatenate_back.dart
+++ b/lib/src/messages/responses/cache/data/list/list_concatenate_back.dart
@@ -24,7 +24,7 @@ class ListConcatenateBackSuccess extends ResponseBase
 
   @override
   String toString() {
-    return "$runtimeType: Length $length";
+    return "${super.toString()}: Length $length";
   }
 }
 

--- a/lib/src/messages/responses/cache/data/list/list_concatenate_back.dart
+++ b/lib/src/messages/responses/cache/data/list/list_concatenate_back.dart
@@ -16,13 +16,16 @@ sealed class ListConcatenateBackResponse {}
 /// Indicates that the request was successful and the updated length can be accessed by the field `length`.
 class ListConcatenateBackSuccess extends NonErroResponseBase
     implements ListConcatenateBackResponse {
-  ListConcatenateBackSuccess(this._length,
-      {String message = "ListConcatenateBackSuccess"})
-      : super(message);
+  ListConcatenateBackSuccess(this._length);
 
   final int _length;
 
   int get length => _length;
+
+  @override
+  String toString() {
+    return "$runtimeType: Length $length";
+  }
 }
 
 /// Indicates that an error occurred during the list concatenate back request.

--- a/lib/src/messages/responses/cache/data/list/list_concatenate_back.dart
+++ b/lib/src/messages/responses/cache/data/list/list_concatenate_back.dart
@@ -14,8 +14,11 @@ import '../../../responses_base.dart';
 sealed class ListConcatenateBackResponse {}
 
 /// Indicates that the request was successful and the updated length can be accessed by the field `length`.
-class ListConcatenateBackSuccess implements ListConcatenateBackResponse {
-  ListConcatenateBackSuccess(this._length);
+class ListConcatenateBackSuccess extends NonErroResponseBase
+    implements ListConcatenateBackResponse {
+  ListConcatenateBackSuccess(this._length,
+      {String message = "ListConcatenateBackSuccess"})
+      : super(message);
 
   final int _length;
 

--- a/lib/src/messages/responses/cache/data/list/list_concatenate_back.dart
+++ b/lib/src/messages/responses/cache/data/list/list_concatenate_back.dart
@@ -14,7 +14,7 @@ import '../../../responses_base.dart';
 sealed class ListConcatenateBackResponse {}
 
 /// Indicates that the request was successful and the updated length can be accessed by the field `length`.
-class ListConcatenateBackSuccess extends NonErrorResponseBase
+class ListConcatenateBackSuccess extends ResponseBase
     implements ListConcatenateBackResponse {
   ListConcatenateBackSuccess(this._length);
 

--- a/lib/src/messages/responses/cache/data/list/list_concatenate_back.dart
+++ b/lib/src/messages/responses/cache/data/list/list_concatenate_back.dart
@@ -14,7 +14,7 @@ import '../../../responses_base.dart';
 sealed class ListConcatenateBackResponse {}
 
 /// Indicates that the request was successful and the updated length can be accessed by the field `length`.
-class ListConcatenateBackSuccess extends NonErroResponseBase
+class ListConcatenateBackSuccess extends NonErrorResponseBase
     implements ListConcatenateBackResponse {
   ListConcatenateBackSuccess(this._length);
 

--- a/lib/src/messages/responses/cache/data/list/list_concatenate_front.dart
+++ b/lib/src/messages/responses/cache/data/list/list_concatenate_front.dart
@@ -14,7 +14,7 @@ import '../../../responses_base.dart';
 sealed class ListConcatenateFrontResponse {}
 
 /// Indicates that the request was successful and the updated length can be accessed by the field `length`.
-class ListConcatenateFrontSuccess extends NonErrorResponseBase
+class ListConcatenateFrontSuccess extends ResponseBase
     implements ListConcatenateFrontResponse {
   ListConcatenateFrontSuccess(this._length);
 

--- a/lib/src/messages/responses/cache/data/list/list_concatenate_front.dart
+++ b/lib/src/messages/responses/cache/data/list/list_concatenate_front.dart
@@ -14,8 +14,11 @@ import '../../../responses_base.dart';
 sealed class ListConcatenateFrontResponse {}
 
 /// Indicates that the request was successful and the updated length can be accessed by the field `length`.
-class ListConcatenateFrontSuccess implements ListConcatenateFrontResponse {
-  ListConcatenateFrontSuccess(this._length);
+class ListConcatenateFrontSuccess extends NonErroResponseBase
+    implements ListConcatenateFrontResponse {
+  ListConcatenateFrontSuccess(this._length,
+      {String message = "ListConcatenateFrontSuccess"})
+      : super(message);
 
   final int _length;
 

--- a/lib/src/messages/responses/cache/data/list/list_concatenate_front.dart
+++ b/lib/src/messages/responses/cache/data/list/list_concatenate_front.dart
@@ -24,7 +24,7 @@ class ListConcatenateFrontSuccess extends ResponseBase
 
   @override
   String toString() {
-    return "$runtimeType: Length $length";
+    return "${super.toString()}: Length $length";
   }
 }
 

--- a/lib/src/messages/responses/cache/data/list/list_concatenate_front.dart
+++ b/lib/src/messages/responses/cache/data/list/list_concatenate_front.dart
@@ -14,7 +14,7 @@ import '../../../responses_base.dart';
 sealed class ListConcatenateFrontResponse {}
 
 /// Indicates that the request was successful and the updated length can be accessed by the field `length`.
-class ListConcatenateFrontSuccess extends NonErroResponseBase
+class ListConcatenateFrontSuccess extends NonErrorResponseBase
     implements ListConcatenateFrontResponse {
   ListConcatenateFrontSuccess(this._length);
 

--- a/lib/src/messages/responses/cache/data/list/list_concatenate_front.dart
+++ b/lib/src/messages/responses/cache/data/list/list_concatenate_front.dart
@@ -16,13 +16,16 @@ sealed class ListConcatenateFrontResponse {}
 /// Indicates that the request was successful and the updated length can be accessed by the field `length`.
 class ListConcatenateFrontSuccess extends NonErroResponseBase
     implements ListConcatenateFrontResponse {
-  ListConcatenateFrontSuccess(this._length,
-      {String message = "ListConcatenateFrontSuccess"})
-      : super(message);
+  ListConcatenateFrontSuccess(this._length);
 
   final int _length;
 
   int get length => _length;
+
+  @override
+  String toString() {
+    return "$runtimeType: Length $length";
+  }
 }
 
 /// Indicates that an error occurred during the list concatenate front request.

--- a/lib/src/messages/responses/cache/data/list/list_fetch.dart
+++ b/lib/src/messages/responses/cache/data/list/list_fetch.dart
@@ -18,7 +18,7 @@ import 'package:momento/src/messages/responses/responses_base.dart';
 sealed class ListFetchResponse {}
 
 /// Indicates that the requested list was not available in the cache.
-class ListFetchMiss extends NonErrorResponseBase implements ListFetchResponse {}
+class ListFetchMiss extends ResponseBase implements ListFetchResponse {}
 
 /// Indicates that an error occurred during the list fetch request.
 ///
@@ -31,7 +31,7 @@ class ListFetchError extends ErrorResponseBase implements ListFetchResponse {
 }
 
 /// Indicates that the requested list was successfully retrieved from the cache and can be accessed by the fields `values` or `binaryValues`.
-class ListFetchHit extends NonErrorResponseBase implements ListFetchResponse {
+class ListFetchHit extends ResponseBase implements ListFetchResponse {
   ListFetchHit(this._values);
 
   final List<List<int>> _values;

--- a/lib/src/messages/responses/cache/data/list/list_fetch.dart
+++ b/lib/src/messages/responses/cache/data/list/list_fetch.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:momento/src/internal/utils/display.dart';
 import 'package:momento/src/messages/responses/responses_base.dart';
 
 /// Sealed class for a cache list fetch response.
@@ -41,6 +42,6 @@ class ListFetchHit extends ResponseBase implements ListFetchResponse {
 
   @override
   String toString() {
-    return "$runtimeType: $values";
+    return "${super.toString()}: ${truncateStringArray(values.toList())}";
   }
 }

--- a/lib/src/messages/responses/cache/data/list/list_fetch.dart
+++ b/lib/src/messages/responses/cache/data/list/list_fetch.dart
@@ -18,7 +18,9 @@ import 'package:momento/src/messages/responses/responses_base.dart';
 sealed class ListFetchResponse {}
 
 /// Indicates that the requested list was not available in the cache.
-class ListFetchMiss implements ListFetchResponse {}
+class ListFetchMiss extends NonErroResponseBase implements ListFetchResponse {
+  ListFetchMiss({String message = "ListFetchMiss"}) : super(message);
+}
 
 /// Indicates that an error occurred during the list fetch request.
 ///
@@ -31,8 +33,9 @@ class ListFetchError extends ErrorResponseBase implements ListFetchResponse {
 }
 
 /// Indicates that the requested list was successfully retrieved from the cache and can be accessed by the fields `values` or `binaryValues`.
-class ListFetchHit implements ListFetchResponse {
-  ListFetchHit(this._values);
+class ListFetchHit extends NonErroResponseBase implements ListFetchResponse {
+  ListFetchHit(this._values, {String message = "ListFetchHit"})
+      : super(message);
 
   final List<List<int>> _values;
 

--- a/lib/src/messages/responses/cache/data/list/list_fetch.dart
+++ b/lib/src/messages/responses/cache/data/list/list_fetch.dart
@@ -18,7 +18,7 @@ import 'package:momento/src/messages/responses/responses_base.dart';
 sealed class ListFetchResponse {}
 
 /// Indicates that the requested list was not available in the cache.
-class ListFetchMiss extends NonErroResponseBase implements ListFetchResponse {}
+class ListFetchMiss extends NonErrorResponseBase implements ListFetchResponse {}
 
 /// Indicates that an error occurred during the list fetch request.
 ///
@@ -31,7 +31,7 @@ class ListFetchError extends ErrorResponseBase implements ListFetchResponse {
 }
 
 /// Indicates that the requested list was successfully retrieved from the cache and can be accessed by the fields `values` or `binaryValues`.
-class ListFetchHit extends NonErroResponseBase implements ListFetchResponse {
+class ListFetchHit extends NonErrorResponseBase implements ListFetchResponse {
   ListFetchHit(this._values);
 
   final List<List<int>> _values;

--- a/lib/src/messages/responses/cache/data/list/list_fetch.dart
+++ b/lib/src/messages/responses/cache/data/list/list_fetch.dart
@@ -18,9 +18,7 @@ import 'package:momento/src/messages/responses/responses_base.dart';
 sealed class ListFetchResponse {}
 
 /// Indicates that the requested list was not available in the cache.
-class ListFetchMiss extends NonErroResponseBase implements ListFetchResponse {
-  ListFetchMiss({String message = "ListFetchMiss"}) : super(message);
-}
+class ListFetchMiss extends NonErroResponseBase implements ListFetchResponse {}
 
 /// Indicates that an error occurred during the list fetch request.
 ///
@@ -34,11 +32,15 @@ class ListFetchError extends ErrorResponseBase implements ListFetchResponse {
 
 /// Indicates that the requested list was successfully retrieved from the cache and can be accessed by the fields `values` or `binaryValues`.
 class ListFetchHit extends NonErroResponseBase implements ListFetchResponse {
-  ListFetchHit(this._values, {String message = "ListFetchHit"})
-      : super(message);
+  ListFetchHit(this._values);
 
   final List<List<int>> _values;
 
   Iterable<String> get values => _values.map((e) => utf8.decode(e));
   Iterable<List<int>> get binaryValues => _values;
+
+  @override
+  String toString() {
+    return "$runtimeType: $values";
+  }
 }

--- a/lib/src/messages/responses/cache/data/list/list_length.dart
+++ b/lib/src/messages/responses/cache/data/list/list_length.dart
@@ -16,7 +16,7 @@ import '../../../responses_base.dart';
 sealed class ListLengthResponse {}
 
 /// Indicates that the requested list was not available in the cache.
-class ListLengthMiss extends NonErroResponseBase
+class ListLengthMiss extends NonErrorResponseBase
     implements ListLengthResponse {}
 
 /// Indicates that an error occurred during the list length request.
@@ -30,7 +30,7 @@ class ListLengthError extends ErrorResponseBase implements ListLengthResponse {
 }
 
 /// Indicates that the requested list length was successfully retrieved from the cache and the length can be accessed by the field `length`.
-class ListLengthHit extends NonErroResponseBase implements ListLengthResponse {
+class ListLengthHit extends NonErrorResponseBase implements ListLengthResponse {
   ListLengthHit(this._length);
 
   final int _length;

--- a/lib/src/messages/responses/cache/data/list/list_length.dart
+++ b/lib/src/messages/responses/cache/data/list/list_length.dart
@@ -16,7 +16,9 @@ import '../../../responses_base.dart';
 sealed class ListLengthResponse {}
 
 /// Indicates that the requested list was not available in the cache.
-class ListLengthMiss implements ListLengthResponse {}
+class ListLengthMiss extends NonErroResponseBase implements ListLengthResponse {
+  ListLengthMiss({String message = "ListLengthMiss"}) : super(message);
+}
 
 /// Indicates that an error occurred during the list length request.
 ///
@@ -29,8 +31,9 @@ class ListLengthError extends ErrorResponseBase implements ListLengthResponse {
 }
 
 /// Indicates that the requested list length was successfully retrieved from the cache and the length can be accessed by the field `length`.
-class ListLengthHit implements ListLengthResponse {
-  ListLengthHit(this._length);
+class ListLengthHit extends NonErroResponseBase implements ListLengthResponse {
+  ListLengthHit(this._length, {String message = "ListLengthHit"})
+      : super(message);
 
   final int _length;
 

--- a/lib/src/messages/responses/cache/data/list/list_length.dart
+++ b/lib/src/messages/responses/cache/data/list/list_length.dart
@@ -16,7 +16,8 @@ import '../../../responses_base.dart';
 sealed class ListLengthResponse {}
 
 /// Indicates that the requested list was not available in the cache.
-class ListLengthMiss extends NonErroResponseBase implements ListLengthResponse {}
+class ListLengthMiss extends NonErroResponseBase
+    implements ListLengthResponse {}
 
 /// Indicates that an error occurred during the list length request.
 ///

--- a/lib/src/messages/responses/cache/data/list/list_length.dart
+++ b/lib/src/messages/responses/cache/data/list/list_length.dart
@@ -16,9 +16,7 @@ import '../../../responses_base.dart';
 sealed class ListLengthResponse {}
 
 /// Indicates that the requested list was not available in the cache.
-class ListLengthMiss extends NonErroResponseBase implements ListLengthResponse {
-  ListLengthMiss({String message = "ListLengthMiss"}) : super(message);
-}
+class ListLengthMiss extends NonErroResponseBase implements ListLengthResponse {}
 
 /// Indicates that an error occurred during the list length request.
 ///
@@ -32,10 +30,14 @@ class ListLengthError extends ErrorResponseBase implements ListLengthResponse {
 
 /// Indicates that the requested list length was successfully retrieved from the cache and the length can be accessed by the field `length`.
 class ListLengthHit extends NonErroResponseBase implements ListLengthResponse {
-  ListLengthHit(this._length, {String message = "ListLengthHit"})
-      : super(message);
+  ListLengthHit(this._length);
 
   final int _length;
 
   int get length => _length;
+
+  @override
+  String toString() {
+    return "$runtimeType: Length $length";
+  }
 }

--- a/lib/src/messages/responses/cache/data/list/list_length.dart
+++ b/lib/src/messages/responses/cache/data/list/list_length.dart
@@ -16,8 +16,7 @@ import '../../../responses_base.dart';
 sealed class ListLengthResponse {}
 
 /// Indicates that the requested list was not available in the cache.
-class ListLengthMiss extends NonErrorResponseBase
-    implements ListLengthResponse {}
+class ListLengthMiss extends ResponseBase implements ListLengthResponse {}
 
 /// Indicates that an error occurred during the list length request.
 ///
@@ -30,7 +29,7 @@ class ListLengthError extends ErrorResponseBase implements ListLengthResponse {
 }
 
 /// Indicates that the requested list length was successfully retrieved from the cache and the length can be accessed by the field `length`.
-class ListLengthHit extends NonErrorResponseBase implements ListLengthResponse {
+class ListLengthHit extends ResponseBase implements ListLengthResponse {
   ListLengthHit(this._length);
 
   final int _length;

--- a/lib/src/messages/responses/cache/data/list/list_length.dart
+++ b/lib/src/messages/responses/cache/data/list/list_length.dart
@@ -38,6 +38,6 @@ class ListLengthHit extends ResponseBase implements ListLengthResponse {
 
   @override
   String toString() {
-    return "$runtimeType: Length $length";
+    return "${super.toString()}: Length $length";
   }
 }

--- a/lib/src/messages/responses/cache/data/list/list_pop_back.dart
+++ b/lib/src/messages/responses/cache/data/list/list_pop_back.dart
@@ -18,7 +18,10 @@ import '../../../responses_base.dart';
 sealed class ListPopBackResponse {}
 
 /// Indicates that the requested list was not available in the cache.
-class ListPopBackMiss implements ListPopBackResponse {}
+class ListPopBackMiss extends NonErroResponseBase
+    implements ListPopBackResponse {
+  ListPopBackMiss({String message = "ListPopBackMiss"}) : super(message);
+}
 
 /// Indicates that an error occurred during the list pop back request.
 ///
@@ -32,8 +35,10 @@ class ListPopBackError extends ErrorResponseBase
 }
 
 /// Indicates that the request was successful and the value can be accessed by the fields `value` or `binaryValue`.
-class ListPopBackHit implements ListPopBackResponse {
-  ListPopBackHit(this._value);
+class ListPopBackHit extends NonErroResponseBase
+    implements ListPopBackResponse {
+  ListPopBackHit(this._value, {String message = "ListPopBackHit"})
+      : super(message);
 
   final List<int> _value;
 

--- a/lib/src/messages/responses/cache/data/list/list_pop_back.dart
+++ b/lib/src/messages/responses/cache/data/list/list_pop_back.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
 
+import 'package:momento/src/internal/utils/display.dart';
+
 import '../../../responses_base.dart';
 
 /// Sealed class for a cache list pop back response.
@@ -42,6 +44,6 @@ class ListPopBackHit extends ResponseBase implements ListPopBackResponse {
 
   @override
   String toString() {
-    return "$runtimeType: $value";
+    return "${super.toString()}: ${truncateString(value)}";
   }
 }

--- a/lib/src/messages/responses/cache/data/list/list_pop_back.dart
+++ b/lib/src/messages/responses/cache/data/list/list_pop_back.dart
@@ -18,8 +18,7 @@ import '../../../responses_base.dart';
 sealed class ListPopBackResponse {}
 
 /// Indicates that the requested list was not available in the cache.
-class ListPopBackMiss extends NonErrorResponseBase
-    implements ListPopBackResponse {}
+class ListPopBackMiss extends ResponseBase implements ListPopBackResponse {}
 
 /// Indicates that an error occurred during the list pop back request.
 ///
@@ -33,8 +32,7 @@ class ListPopBackError extends ErrorResponseBase
 }
 
 /// Indicates that the request was successful and the value can be accessed by the fields `value` or `binaryValue`.
-class ListPopBackHit extends NonErrorResponseBase
-    implements ListPopBackResponse {
+class ListPopBackHit extends ResponseBase implements ListPopBackResponse {
   ListPopBackHit(this._value);
 
   final List<int> _value;

--- a/lib/src/messages/responses/cache/data/list/list_pop_back.dart
+++ b/lib/src/messages/responses/cache/data/list/list_pop_back.dart
@@ -19,9 +19,7 @@ sealed class ListPopBackResponse {}
 
 /// Indicates that the requested list was not available in the cache.
 class ListPopBackMiss extends NonErroResponseBase
-    implements ListPopBackResponse {
-  ListPopBackMiss({String message = "ListPopBackMiss"}) : super(message);
-}
+    implements ListPopBackResponse {}
 
 /// Indicates that an error occurred during the list pop back request.
 ///
@@ -37,11 +35,15 @@ class ListPopBackError extends ErrorResponseBase
 /// Indicates that the request was successful and the value can be accessed by the fields `value` or `binaryValue`.
 class ListPopBackHit extends NonErroResponseBase
     implements ListPopBackResponse {
-  ListPopBackHit(this._value, {String message = "ListPopBackHit"})
-      : super(message);
+  ListPopBackHit(this._value);
 
   final List<int> _value;
 
   String get value => utf8.decode(_value);
   List<int> get binaryValue => _value;
+
+  @override
+  String toString() {
+    return "$runtimeType: $value";
+  }
 }

--- a/lib/src/messages/responses/cache/data/list/list_pop_back.dart
+++ b/lib/src/messages/responses/cache/data/list/list_pop_back.dart
@@ -18,7 +18,7 @@ import '../../../responses_base.dart';
 sealed class ListPopBackResponse {}
 
 /// Indicates that the requested list was not available in the cache.
-class ListPopBackMiss extends NonErroResponseBase
+class ListPopBackMiss extends NonErrorResponseBase
     implements ListPopBackResponse {}
 
 /// Indicates that an error occurred during the list pop back request.
@@ -33,7 +33,7 @@ class ListPopBackError extends ErrorResponseBase
 }
 
 /// Indicates that the request was successful and the value can be accessed by the fields `value` or `binaryValue`.
-class ListPopBackHit extends NonErroResponseBase
+class ListPopBackHit extends NonErrorResponseBase
     implements ListPopBackResponse {
   ListPopBackHit(this._value);
 

--- a/lib/src/messages/responses/cache/data/list/list_pop_front.dart
+++ b/lib/src/messages/responses/cache/data/list/list_pop_front.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
 
+import 'package:momento/src/internal/utils/display.dart';
+
 import '../../../responses_base.dart';
 
 /// Sealed class for a cache list pop front response.
@@ -42,6 +44,6 @@ class ListPopFrontHit extends ResponseBase implements ListPopFrontResponse {
 
   @override
   String toString() {
-    return "$runtimeType: $value";
+    return "${super.toString()}: ${truncateString(value)}";
   }
 }

--- a/lib/src/messages/responses/cache/data/list/list_pop_front.dart
+++ b/lib/src/messages/responses/cache/data/list/list_pop_front.dart
@@ -18,7 +18,7 @@ import '../../../responses_base.dart';
 sealed class ListPopFrontResponse {}
 
 /// Indicates that the requested list was not available in the cache.
-class ListPopFrontMiss extends NonErroResponseBase
+class ListPopFrontMiss extends NonErrorResponseBase
     implements ListPopFrontResponse {}
 
 /// Indicates that an error occurred during the list pop front request.
@@ -33,7 +33,7 @@ class ListPopFrontError extends ErrorResponseBase
 }
 
 /// Indicates that the request was successful and the value can be accessed by the fields `value` or `binaryValue`.
-class ListPopFrontHit extends NonErroResponseBase
+class ListPopFrontHit extends NonErrorResponseBase
     implements ListPopFrontResponse {
   ListPopFrontHit(this._value);
 

--- a/lib/src/messages/responses/cache/data/list/list_pop_front.dart
+++ b/lib/src/messages/responses/cache/data/list/list_pop_front.dart
@@ -18,8 +18,7 @@ import '../../../responses_base.dart';
 sealed class ListPopFrontResponse {}
 
 /// Indicates that the requested list was not available in the cache.
-class ListPopFrontMiss extends NonErrorResponseBase
-    implements ListPopFrontResponse {}
+class ListPopFrontMiss extends ResponseBase implements ListPopFrontResponse {}
 
 /// Indicates that an error occurred during the list pop front request.
 ///
@@ -33,8 +32,7 @@ class ListPopFrontError extends ErrorResponseBase
 }
 
 /// Indicates that the request was successful and the value can be accessed by the fields `value` or `binaryValue`.
-class ListPopFrontHit extends NonErrorResponseBase
-    implements ListPopFrontResponse {
+class ListPopFrontHit extends ResponseBase implements ListPopFrontResponse {
   ListPopFrontHit(this._value);
 
   final List<int> _value;

--- a/lib/src/messages/responses/cache/data/list/list_pop_front.dart
+++ b/lib/src/messages/responses/cache/data/list/list_pop_front.dart
@@ -19,9 +19,7 @@ sealed class ListPopFrontResponse {}
 
 /// Indicates that the requested list was not available in the cache.
 class ListPopFrontMiss extends NonErroResponseBase
-    implements ListPopFrontResponse {
-  ListPopFrontMiss({String message = "ListPopFrontMiss"}) : super(message);
-}
+    implements ListPopFrontResponse {}
 
 /// Indicates that an error occurred during the list pop front request.
 ///
@@ -37,11 +35,15 @@ class ListPopFrontError extends ErrorResponseBase
 /// Indicates that the request was successful and the value can be accessed by the fields `value` or `binaryValue`.
 class ListPopFrontHit extends NonErroResponseBase
     implements ListPopFrontResponse {
-  ListPopFrontHit(this._value, {String message = "ListPopFrontHit"})
-      : super(message);
+  ListPopFrontHit(this._value);
 
   final List<int> _value;
 
   String get value => utf8.decode(_value);
   List<int> get binaryValue => _value;
+
+  @override
+  String toString() {
+    return "$runtimeType: $value";
+  }
 }

--- a/lib/src/messages/responses/cache/data/list/list_pop_front.dart
+++ b/lib/src/messages/responses/cache/data/list/list_pop_front.dart
@@ -18,7 +18,10 @@ import '../../../responses_base.dart';
 sealed class ListPopFrontResponse {}
 
 /// Indicates that the requested list was not available in the cache.
-class ListPopFrontMiss implements ListPopFrontResponse {}
+class ListPopFrontMiss extends NonErroResponseBase
+    implements ListPopFrontResponse {
+  ListPopFrontMiss({String message = "ListPopFrontMiss"}) : super(message);
+}
 
 /// Indicates that an error occurred during the list pop front request.
 ///
@@ -32,8 +35,10 @@ class ListPopFrontError extends ErrorResponseBase
 }
 
 /// Indicates that the request was successful and the value can be accessed by the fields `value` or `binaryValue`.
-class ListPopFrontHit implements ListPopFrontResponse {
-  ListPopFrontHit(this._value);
+class ListPopFrontHit extends NonErroResponseBase
+    implements ListPopFrontResponse {
+  ListPopFrontHit(this._value, {String message = "ListPopFrontHit"})
+      : super(message);
 
   final List<int> _value;
 

--- a/lib/src/messages/responses/cache/data/list/list_push_back.dart
+++ b/lib/src/messages/responses/cache/data/list/list_push_back.dart
@@ -25,7 +25,7 @@ class ListPushBackError extends ErrorResponseBase
 }
 
 /// Indicates that the request was successful and the updated length can be accessed by the field `length`.
-class ListPushBackSuccess extends NonErroResponseBase
+class ListPushBackSuccess extends NonErrorResponseBase
     implements ListPushBackResponse {
   ListPushBackSuccess(this._length);
 

--- a/lib/src/messages/responses/cache/data/list/list_push_back.dart
+++ b/lib/src/messages/responses/cache/data/list/list_push_back.dart
@@ -34,6 +34,6 @@ class ListPushBackSuccess extends ResponseBase implements ListPushBackResponse {
 
   @override
   String toString() {
-    return "$runtimeType: Length $length";
+    return "${super.toString()}: Length $length";
   }
 }

--- a/lib/src/messages/responses/cache/data/list/list_push_back.dart
+++ b/lib/src/messages/responses/cache/data/list/list_push_back.dart
@@ -25,8 +25,7 @@ class ListPushBackError extends ErrorResponseBase
 }
 
 /// Indicates that the request was successful and the updated length can be accessed by the field `length`.
-class ListPushBackSuccess extends NonErrorResponseBase
-    implements ListPushBackResponse {
+class ListPushBackSuccess extends ResponseBase implements ListPushBackResponse {
   ListPushBackSuccess(this._length);
 
   final int _length;

--- a/lib/src/messages/responses/cache/data/list/list_push_back.dart
+++ b/lib/src/messages/responses/cache/data/list/list_push_back.dart
@@ -27,10 +27,14 @@ class ListPushBackError extends ErrorResponseBase
 /// Indicates that the request was successful and the updated length can be accessed by the field `length`.
 class ListPushBackSuccess extends NonErroResponseBase
     implements ListPushBackResponse {
-  ListPushBackSuccess(this._length, {String message = "ListPushBackSuccess"})
-      : super(message);
+  ListPushBackSuccess(this._length);
 
   final int _length;
 
   int get length => _length;
+
+  @override
+  String toString() {
+    return "$runtimeType: Length $length";
+  }
 }

--- a/lib/src/messages/responses/cache/data/list/list_push_back.dart
+++ b/lib/src/messages/responses/cache/data/list/list_push_back.dart
@@ -25,8 +25,10 @@ class ListPushBackError extends ErrorResponseBase
 }
 
 /// Indicates that the request was successful and the updated length can be accessed by the field `length`.
-class ListPushBackSuccess implements ListPushBackResponse {
-  ListPushBackSuccess(this._length);
+class ListPushBackSuccess extends NonErroResponseBase
+    implements ListPushBackResponse {
+  ListPushBackSuccess(this._length, {String message = "ListPushBackSuccess"})
+      : super(message);
 
   final int _length;
 

--- a/lib/src/messages/responses/cache/data/list/list_push_front.dart
+++ b/lib/src/messages/responses/cache/data/list/list_push_front.dart
@@ -35,6 +35,6 @@ class ListPushFrontSuccess extends ResponseBase
 
   @override
   String toString() {
-    return "$runtimeType: Length $length";
+    return "${super.toString()}: Length $length";
   }
 }

--- a/lib/src/messages/responses/cache/data/list/list_push_front.dart
+++ b/lib/src/messages/responses/cache/data/list/list_push_front.dart
@@ -25,7 +25,7 @@ class ListPushFrontError extends ErrorResponseBase
 }
 
 /// Indicates that the request was successful and the updated length can be accessed by the field `length`.
-class ListPushFrontSuccess extends NonErrorResponseBase
+class ListPushFrontSuccess extends ResponseBase
     implements ListPushFrontResponse {
   ListPushFrontSuccess(this._length);
 

--- a/lib/src/messages/responses/cache/data/list/list_push_front.dart
+++ b/lib/src/messages/responses/cache/data/list/list_push_front.dart
@@ -25,8 +25,10 @@ class ListPushFrontError extends ErrorResponseBase
 }
 
 /// Indicates that the request was successful and the updated length can be accessed by the field `length`.
-class ListPushFrontSuccess implements ListPushFrontResponse {
-  ListPushFrontSuccess(this._length);
+class ListPushFrontSuccess extends NonErroResponseBase
+    implements ListPushFrontResponse {
+  ListPushFrontSuccess(this._length, {String message = "ListPushFrontSuccess"})
+      : super(message);
 
   final int _length;
 

--- a/lib/src/messages/responses/cache/data/list/list_push_front.dart
+++ b/lib/src/messages/responses/cache/data/list/list_push_front.dart
@@ -27,10 +27,14 @@ class ListPushFrontError extends ErrorResponseBase
 /// Indicates that the request was successful and the updated length can be accessed by the field `length`.
 class ListPushFrontSuccess extends NonErroResponseBase
     implements ListPushFrontResponse {
-  ListPushFrontSuccess(this._length, {String message = "ListPushFrontSuccess"})
-      : super(message);
+  ListPushFrontSuccess(this._length);
 
   final int _length;
 
   int get length => _length;
+
+  @override
+  String toString() {
+    return "$runtimeType: Length $length";
+  }
 }

--- a/lib/src/messages/responses/cache/data/list/list_push_front.dart
+++ b/lib/src/messages/responses/cache/data/list/list_push_front.dart
@@ -25,7 +25,7 @@ class ListPushFrontError extends ErrorResponseBase
 }
 
 /// Indicates that the request was successful and the updated length can be accessed by the field `length`.
-class ListPushFrontSuccess extends NonErroResponseBase
+class ListPushFrontSuccess extends NonErrorResponseBase
     implements ListPushFrontResponse {
   ListPushFrontSuccess(this._length);
 

--- a/lib/src/messages/responses/cache/data/list/list_remove_value.dart
+++ b/lib/src/messages/responses/cache/data/list/list_remove_value.dart
@@ -14,7 +14,11 @@ import '../../../responses_base.dart';
 sealed class ListRemoveValueResponse {}
 
 /// Indicates that the request was successful.
-class ListRemoveValueSuccess implements ListRemoveValueResponse {}
+class ListRemoveValueSuccess extends NonErroResponseBase
+    implements ListRemoveValueResponse {
+  ListRemoveValueSuccess({String message = "ListRemoveValueSuccess"})
+      : super(message);
+}
 
 /// Indicates that an error occurred during the list remove value request.
 ///

--- a/lib/src/messages/responses/cache/data/list/list_remove_value.dart
+++ b/lib/src/messages/responses/cache/data/list/list_remove_value.dart
@@ -14,7 +14,7 @@ import '../../../responses_base.dart';
 sealed class ListRemoveValueResponse {}
 
 /// Indicates that the request was successful.
-class ListRemoveValueSuccess extends NonErrorResponseBase
+class ListRemoveValueSuccess extends ResponseBase
     implements ListRemoveValueResponse {}
 
 /// Indicates that an error occurred during the list remove value request.

--- a/lib/src/messages/responses/cache/data/list/list_remove_value.dart
+++ b/lib/src/messages/responses/cache/data/list/list_remove_value.dart
@@ -15,10 +15,7 @@ sealed class ListRemoveValueResponse {}
 
 /// Indicates that the request was successful.
 class ListRemoveValueSuccess extends NonErroResponseBase
-    implements ListRemoveValueResponse {
-  ListRemoveValueSuccess({String message = "ListRemoveValueSuccess"})
-      : super(message);
-}
+    implements ListRemoveValueResponse {}
 
 /// Indicates that an error occurred during the list remove value request.
 ///

--- a/lib/src/messages/responses/cache/data/list/list_remove_value.dart
+++ b/lib/src/messages/responses/cache/data/list/list_remove_value.dart
@@ -14,7 +14,7 @@ import '../../../responses_base.dart';
 sealed class ListRemoveValueResponse {}
 
 /// Indicates that the request was successful.
-class ListRemoveValueSuccess extends NonErroResponseBase
+class ListRemoveValueSuccess extends NonErrorResponseBase
     implements ListRemoveValueResponse {}
 
 /// Indicates that an error occurred during the list remove value request.

--- a/lib/src/messages/responses/cache/data/list/list_retain.dart
+++ b/lib/src/messages/responses/cache/data/list/list_retain.dart
@@ -14,8 +14,7 @@ import '../../../responses_base.dart';
 sealed class ListRetainResponse {}
 
 /// Indicates that the request was successful.
-class ListRetainSuccess extends NonErrorResponseBase
-    implements ListRetainResponse {}
+class ListRetainSuccess extends ResponseBase implements ListRetainResponse {}
 
 /// Indicates that an error occurred during the list retain request.
 ///

--- a/lib/src/messages/responses/cache/data/list/list_retain.dart
+++ b/lib/src/messages/responses/cache/data/list/list_retain.dart
@@ -14,7 +14,10 @@ import '../../../responses_base.dart';
 sealed class ListRetainResponse {}
 
 /// Indicates that the request was successful.
-class ListRetainSuccess implements ListRetainResponse {}
+class ListRetainSuccess extends NonErroResponseBase
+    implements ListRetainResponse {
+  ListRetainSuccess({String message = "ListRetainSuccess"}) : super(message);
+}
 
 /// Indicates that an error occurred during the list retain request.
 ///

--- a/lib/src/messages/responses/cache/data/list/list_retain.dart
+++ b/lib/src/messages/responses/cache/data/list/list_retain.dart
@@ -14,7 +14,7 @@ import '../../../responses_base.dart';
 sealed class ListRetainResponse {}
 
 /// Indicates that the request was successful.
-class ListRetainSuccess extends NonErroResponseBase
+class ListRetainSuccess extends NonErrorResponseBase
     implements ListRetainResponse {}
 
 /// Indicates that an error occurred during the list retain request.

--- a/lib/src/messages/responses/cache/data/list/list_retain.dart
+++ b/lib/src/messages/responses/cache/data/list/list_retain.dart
@@ -15,9 +15,7 @@ sealed class ListRetainResponse {}
 
 /// Indicates that the request was successful.
 class ListRetainSuccess extends NonErroResponseBase
-    implements ListRetainResponse {
-  ListRetainSuccess({String message = "ListRetainSuccess"}) : super(message);
-}
+    implements ListRetainResponse {}
 
 /// Indicates that an error occurred during the list retain request.
 ///

--- a/lib/src/messages/responses/cache/data/scalar/delete_response.dart
+++ b/lib/src/messages/responses/cache/data/scalar/delete_response.dart
@@ -14,7 +14,7 @@ import 'package:momento/src/messages/responses/responses_base.dart';
 sealed class DeleteResponse {}
 
 /// Indicates a successful delete cache item request.
-class DeleteSuccess extends NonErroResponseBase implements DeleteResponse {}
+class DeleteSuccess extends NonErrorResponseBase implements DeleteResponse {}
 
 /// Indicates that an error occurred during the delete cache item request.
 ///

--- a/lib/src/messages/responses/cache/data/scalar/delete_response.dart
+++ b/lib/src/messages/responses/cache/data/scalar/delete_response.dart
@@ -14,7 +14,9 @@ import 'package:momento/src/messages/responses/responses_base.dart';
 sealed class DeleteResponse {}
 
 /// Indicates a successful delete cache item request.
-class DeleteSuccess implements DeleteResponse {}
+class DeleteSuccess extends NonErroResponseBase implements DeleteResponse {
+  DeleteSuccess({String message = "DeleteSuccess"}) : super(message);
+}
 
 /// Indicates that an error occurred during the delete cache item request.
 ///

--- a/lib/src/messages/responses/cache/data/scalar/delete_response.dart
+++ b/lib/src/messages/responses/cache/data/scalar/delete_response.dart
@@ -14,9 +14,7 @@ import 'package:momento/src/messages/responses/responses_base.dart';
 sealed class DeleteResponse {}
 
 /// Indicates a successful delete cache item request.
-class DeleteSuccess extends NonErroResponseBase implements DeleteResponse {
-  DeleteSuccess({String message = "DeleteSuccess"}) : super(message);
-}
+class DeleteSuccess extends NonErroResponseBase implements DeleteResponse {}
 
 /// Indicates that an error occurred during the delete cache item request.
 ///

--- a/lib/src/messages/responses/cache/data/scalar/delete_response.dart
+++ b/lib/src/messages/responses/cache/data/scalar/delete_response.dart
@@ -14,7 +14,7 @@ import 'package:momento/src/messages/responses/responses_base.dart';
 sealed class DeleteResponse {}
 
 /// Indicates a successful delete cache item request.
-class DeleteSuccess extends NonErrorResponseBase implements DeleteResponse {}
+class DeleteSuccess extends ResponseBase implements DeleteResponse {}
 
 /// Indicates that an error occurred during the delete cache item request.
 ///

--- a/lib/src/messages/responses/cache/data/scalar/get_response.dart
+++ b/lib/src/messages/responses/cache/data/scalar/get_response.dart
@@ -18,9 +18,7 @@ import 'package:momento/src/messages/responses/responses_base.dart';
 sealed class GetResponse {}
 
 /// Indicates that the requested data was not available in the cache.
-class GetMiss extends NonErroResponseBase implements GetResponse {
-  GetMiss({String message = "GetMiss"}) : super(message);
-}
+class GetMiss extends NonErroResponseBase implements GetResponse {}
 
 /// Indicates that an error occurred during the get cache item request.
 ///
@@ -34,10 +32,15 @@ class GetError extends ErrorResponseBase implements GetResponse {
 
 /// Indicates that the requested data was successfully retrieved from the cache and can be accessed by the fields `value` or `binaryValue`.
 class GetHit extends NonErroResponseBase implements GetResponse {
-  GetHit(this._value, {String message = "GetHit"}) : super(message);
+  GetHit(this._value);
 
   final List<int> _value;
 
   String get value => utf8.decode(_value);
   List<int> get binaryValue => _value;
+
+  @override
+  String toString() {
+    return "$runtimeType: $value";
+  }
 }

--- a/lib/src/messages/responses/cache/data/scalar/get_response.dart
+++ b/lib/src/messages/responses/cache/data/scalar/get_response.dart
@@ -18,7 +18,7 @@ import 'package:momento/src/messages/responses/responses_base.dart';
 sealed class GetResponse {}
 
 /// Indicates that the requested data was not available in the cache.
-class GetMiss extends NonErrorResponseBase implements GetResponse {}
+class GetMiss extends ResponseBase implements GetResponse {}
 
 /// Indicates that an error occurred during the get cache item request.
 ///
@@ -31,7 +31,7 @@ class GetError extends ErrorResponseBase implements GetResponse {
 }
 
 /// Indicates that the requested data was successfully retrieved from the cache and can be accessed by the fields `value` or `binaryValue`.
-class GetHit extends NonErrorResponseBase implements GetResponse {
+class GetHit extends ResponseBase implements GetResponse {
   GetHit(this._value);
 
   final List<int> _value;

--- a/lib/src/messages/responses/cache/data/scalar/get_response.dart
+++ b/lib/src/messages/responses/cache/data/scalar/get_response.dart
@@ -18,7 +18,7 @@ import 'package:momento/src/messages/responses/responses_base.dart';
 sealed class GetResponse {}
 
 /// Indicates that the requested data was not available in the cache.
-class GetMiss extends NonErroResponseBase implements GetResponse {}
+class GetMiss extends NonErrorResponseBase implements GetResponse {}
 
 /// Indicates that an error occurred during the get cache item request.
 ///
@@ -31,7 +31,7 @@ class GetError extends ErrorResponseBase implements GetResponse {
 }
 
 /// Indicates that the requested data was successfully retrieved from the cache and can be accessed by the fields `value` or `binaryValue`.
-class GetHit extends NonErroResponseBase implements GetResponse {
+class GetHit extends NonErrorResponseBase implements GetResponse {
   GetHit(this._value);
 
   final List<int> _value;

--- a/lib/src/messages/responses/cache/data/scalar/get_response.dart
+++ b/lib/src/messages/responses/cache/data/scalar/get_response.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:momento/src/internal/utils/display.dart';
 import 'package:momento/src/messages/responses/responses_base.dart';
 
 /// Sealed class for a get cache item request.
@@ -41,6 +42,6 @@ class GetHit extends ResponseBase implements GetResponse {
 
   @override
   String toString() {
-    return "$runtimeType: $value";
+    return "${super.toString()}: ${truncateString(value)}";
   }
 }

--- a/lib/src/messages/responses/cache/data/scalar/get_response.dart
+++ b/lib/src/messages/responses/cache/data/scalar/get_response.dart
@@ -18,7 +18,9 @@ import 'package:momento/src/messages/responses/responses_base.dart';
 sealed class GetResponse {}
 
 /// Indicates that the requested data was not available in the cache.
-class GetMiss implements GetResponse {}
+class GetMiss extends NonErroResponseBase implements GetResponse {
+  GetMiss({String message = "GetMiss"}) : super(message);
+}
 
 /// Indicates that an error occurred during the get cache item request.
 ///
@@ -31,8 +33,8 @@ class GetError extends ErrorResponseBase implements GetResponse {
 }
 
 /// Indicates that the requested data was successfully retrieved from the cache and can be accessed by the fields `value` or `binaryValue`.
-class GetHit implements GetResponse {
-  GetHit(this._value);
+class GetHit extends NonErroResponseBase implements GetResponse {
+  GetHit(this._value, {String message = "GetHit"}) : super(message);
 
   final List<int> _value;
 

--- a/lib/src/messages/responses/cache/data/scalar/set_response.dart
+++ b/lib/src/messages/responses/cache/data/scalar/set_response.dart
@@ -14,7 +14,7 @@ import 'package:momento/src/messages/responses/responses_base.dart';
 sealed class SetResponse {}
 
 /// Indicates a successful set cache item request.
-class SetSuccess extends NonErroResponseBase implements SetResponse {}
+class SetSuccess extends NonErrorResponseBase implements SetResponse {}
 
 /// Indicates that an error occurred during the set cache item request.
 ///

--- a/lib/src/messages/responses/cache/data/scalar/set_response.dart
+++ b/lib/src/messages/responses/cache/data/scalar/set_response.dart
@@ -14,9 +14,7 @@ import 'package:momento/src/messages/responses/responses_base.dart';
 sealed class SetResponse {}
 
 /// Indicates a successful set cache item request.
-class SetSuccess extends NonErroResponseBase implements SetResponse {
-  SetSuccess({String message = "SetSuccess"}) : super(message);
-}
+class SetSuccess extends NonErroResponseBase implements SetResponse {}
 
 /// Indicates that an error occurred during the set cache item request.
 ///

--- a/lib/src/messages/responses/cache/data/scalar/set_response.dart
+++ b/lib/src/messages/responses/cache/data/scalar/set_response.dart
@@ -14,7 +14,9 @@ import 'package:momento/src/messages/responses/responses_base.dart';
 sealed class SetResponse {}
 
 /// Indicates a successful set cache item request.
-class SetSuccess implements SetResponse {}
+class SetSuccess extends NonErroResponseBase implements SetResponse {
+  SetSuccess({String message = "SetSuccess"}) : super(message);
+}
 
 /// Indicates that an error occurred during the set cache item request.
 ///

--- a/lib/src/messages/responses/cache/data/scalar/set_response.dart
+++ b/lib/src/messages/responses/cache/data/scalar/set_response.dart
@@ -14,7 +14,7 @@ import 'package:momento/src/messages/responses/responses_base.dart';
 sealed class SetResponse {}
 
 /// Indicates a successful set cache item request.
-class SetSuccess extends NonErrorResponseBase implements SetResponse {}
+class SetSuccess extends ResponseBase implements SetResponse {}
 
 /// Indicates that an error occurred during the set cache item request.
 ///

--- a/lib/src/messages/responses/responses_base.dart
+++ b/lib/src/messages/responses/responses_base.dart
@@ -10,3 +10,14 @@ class ErrorResponseBase extends AbstractExceptionResponseBase
     return "[${super.errorCode}] ${super.message}";
   }
 }
+
+class NonErroResponseBase {
+  final String _message;
+
+  NonErroResponseBase(this._message);
+
+  @override
+  String toString() {
+    return _message;
+  }
+}

--- a/lib/src/messages/responses/responses_base.dart
+++ b/lib/src/messages/responses/responses_base.dart
@@ -11,7 +11,7 @@ class ErrorResponseBase extends AbstractExceptionResponseBase
   }
 }
 
-class NonErrorResponseBase {
+class ResponseBase {
   @override
   String toString() {
     return "$runtimeType";

--- a/lib/src/messages/responses/responses_base.dart
+++ b/lib/src/messages/responses/responses_base.dart
@@ -12,12 +12,8 @@ class ErrorResponseBase extends AbstractExceptionResponseBase
 }
 
 class NonErroResponseBase {
-  final String _message;
-
-  NonErroResponseBase(this._message);
-
   @override
   String toString() {
-    return _message;
+    return "$runtimeType";
   }
 }

--- a/lib/src/messages/responses/responses_base.dart
+++ b/lib/src/messages/responses/responses_base.dart
@@ -11,7 +11,7 @@ class ErrorResponseBase extends AbstractExceptionResponseBase
   }
 }
 
-class NonErroResponseBase {
+class NonErrorResponseBase {
   @override
   String toString() {
     return "$runtimeType";

--- a/lib/src/messages/responses/topics/topic_publish.dart
+++ b/lib/src/messages/responses/topics/topic_publish.dart
@@ -2,7 +2,11 @@ import 'package:momento/src/messages/responses/responses_base.dart';
 
 sealed class TopicPublishResponse {}
 
-class TopicPublishSuccess implements TopicPublishResponse {}
+class TopicPublishSuccess extends NonErroResponseBase
+    implements TopicPublishResponse {
+  TopicPublishSuccess({String message = "TopicPublishSuccess"})
+      : super(message);
+}
 
 class TopicPublishError extends ErrorResponseBase
     implements TopicPublishResponse {

--- a/lib/src/messages/responses/topics/topic_publish.dart
+++ b/lib/src/messages/responses/topics/topic_publish.dart
@@ -2,7 +2,7 @@ import 'package:momento/src/messages/responses/responses_base.dart';
 
 sealed class TopicPublishResponse {}
 
-class TopicPublishSuccess extends NonErrorResponseBase
+class TopicPublishSuccess extends ResponseBase
     implements TopicPublishResponse {}
 
 class TopicPublishError extends ErrorResponseBase

--- a/lib/src/messages/responses/topics/topic_publish.dart
+++ b/lib/src/messages/responses/topics/topic_publish.dart
@@ -3,10 +3,7 @@ import 'package:momento/src/messages/responses/responses_base.dart';
 sealed class TopicPublishResponse {}
 
 class TopicPublishSuccess extends NonErroResponseBase
-    implements TopicPublishResponse {
-  TopicPublishSuccess({String message = "TopicPublishSuccess"})
-      : super(message);
-}
+    implements TopicPublishResponse {}
 
 class TopicPublishError extends ErrorResponseBase
     implements TopicPublishResponse {

--- a/lib/src/messages/responses/topics/topic_publish.dart
+++ b/lib/src/messages/responses/topics/topic_publish.dart
@@ -2,7 +2,7 @@ import 'package:momento/src/messages/responses/responses_base.dart';
 
 sealed class TopicPublishResponse {}
 
-class TopicPublishSuccess extends NonErroResponseBase
+class TopicPublishSuccess extends NonErrorResponseBase
     implements TopicPublishResponse {}
 
 class TopicPublishError extends ErrorResponseBase

--- a/lib/src/messages/responses/topics/topic_subscribe.dart
+++ b/lib/src/messages/responses/topics/topic_subscribe.dart
@@ -10,7 +10,8 @@ import 'topic_subscription_item.dart';
 
 sealed class TopicSubscribeResponse {}
 
-class TopicSubscription implements TopicSubscribeResponse {
+class TopicSubscription extends NonErroResponseBase
+    implements TopicSubscribeResponse {
   ResponseStream<SubscriptionItem_> _stream;
   Int64 lastSequenceNumber;
   final ClientPubsub _client;
@@ -21,7 +22,8 @@ class TopicSubscription implements TopicSubscribeResponse {
   late Stream _broadcastStream;
 
   TopicSubscription(this._stream, this.lastSequenceNumber, this._client,
-      this.cacheName, this.topicName) {
+      this.cacheName, this.topicName)
+      : super("TopicSubscription to topic '$topicName' in cache '$cacheName'") {
     _broadcastStream = _stream.asBroadcastStream();
   }
 

--- a/lib/src/messages/responses/topics/topic_subscribe.dart
+++ b/lib/src/messages/responses/topics/topic_subscribe.dart
@@ -10,8 +10,7 @@ import 'topic_subscription_item.dart';
 
 sealed class TopicSubscribeResponse {}
 
-class TopicSubscription extends NonErrorResponseBase
-    implements TopicSubscribeResponse {
+class TopicSubscription extends ResponseBase implements TopicSubscribeResponse {
   ResponseStream<SubscriptionItem_> _stream;
   Int64 lastSequenceNumber;
   final ClientPubsub _client;

--- a/lib/src/messages/responses/topics/topic_subscribe.dart
+++ b/lib/src/messages/responses/topics/topic_subscribe.dart
@@ -10,7 +10,7 @@ import 'topic_subscription_item.dart';
 
 sealed class TopicSubscribeResponse {}
 
-class TopicSubscription extends NonErroResponseBase
+class TopicSubscription extends NonErrorResponseBase
     implements TopicSubscribeResponse {
   ResponseStream<SubscriptionItem_> _stream;
   Int64 lastSequenceNumber;

--- a/lib/src/messages/responses/topics/topic_subscribe.dart
+++ b/lib/src/messages/responses/topics/topic_subscribe.dart
@@ -22,8 +22,7 @@ class TopicSubscription extends NonErroResponseBase
   late Stream _broadcastStream;
 
   TopicSubscription(this._stream, this.lastSequenceNumber, this._client,
-      this.cacheName, this.topicName)
-      : super("TopicSubscription to topic '$topicName' in cache '$cacheName'") {
+      this.cacheName, this.topicName) {
     _broadcastStream = _stream.asBroadcastStream();
   }
 

--- a/test/src/cache/topics_test.dart
+++ b/test/src/cache/topics_test.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:momento/momento.dart';
 import 'package:momento/src/errors/errors.dart';

--- a/test/src/cache/topics_test.dart
+++ b/test/src/cache/topics_test.dart
@@ -88,7 +88,7 @@ void main() {
       // publish a message 2 seconds from now
       Timer(const Duration(seconds: 2), () async {
         final publishResp = await topicClient.publish(
-          integrationTestCacheName, topicName, StringValue(topicValue));
+            integrationTestCacheName, topicName, StringValue(topicValue));
         switch (publishResp) {
           case TopicPublishSuccess():
             expect(publishResp.runtimeType, TopicPublishSuccess,

--- a/test/src/cache/topics_test.dart
+++ b/test/src/cache/topics_test.dart
@@ -79,7 +79,7 @@ void main() {
               'Expected Success but got Error: ${subscribeResp.errorCode} ${subscribeResp.message}');
       }
 
-      sleep(Duration(seconds: 5));
+      sleep(Duration(seconds: 3));
       final publishResp = await topicClient.publish(
           integrationTestCacheName, topicName, StringValue(topicValue));
       switch (publishResp) {
@@ -90,7 +90,7 @@ void main() {
           fail(
               'Expected Success but got Error: ${publishResp.errorCode} ${publishResp.message}');
       }
-      sleep(Duration(seconds: 5));
+      sleep(Duration(seconds: 3));
 
       try {
         await for (final msg in subscribeResp.stream) {

--- a/test/src/cache/topics_test.dart
+++ b/test/src/cache/topics_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:momento/momento.dart';
@@ -79,18 +80,24 @@ void main() {
               'Expected Success but got Error: ${subscribeResp.errorCode} ${subscribeResp.message}');
       }
 
-      sleep(Duration(seconds: 3));
-      final publishResp = await topicClient.publish(
+      // unsubscribe 10 seconds from now
+      Timer(const Duration(seconds: 10), () {
+        subscribeResp.unsubscribe();
+      });
+
+      // publish a message 2 seconds from now
+      Timer(const Duration(seconds: 2), () async {
+        final publishResp = await topicClient.publish(
           integrationTestCacheName, topicName, StringValue(topicValue));
-      switch (publishResp) {
-        case TopicPublishSuccess():
-          expect(publishResp.runtimeType, TopicPublishSuccess,
-              reason: "publish should succeed");
-        case TopicPublishError():
-          fail(
-              'Expected Success but got Error: ${publishResp.errorCode} ${publishResp.message}');
-      }
-      sleep(Duration(seconds: 3));
+        switch (publishResp) {
+          case TopicPublishSuccess():
+            expect(publishResp.runtimeType, TopicPublishSuccess,
+                reason: "publish should succeed");
+          case TopicPublishError():
+            fail(
+                'Expected Success but got Error: ${publishResp.errorCode} ${publishResp.message}');
+        }
+      });
 
       try {
         await for (final msg in subscribeResp.stream) {
@@ -109,7 +116,6 @@ void main() {
       }
 
       subscribeResp.unsubscribe();
-      topicClient.close();
     });
   });
 }


### PR DESCRIPTION
addresses #78 

Overrode the `toString` function to show more information by default when non-error response objects are printed out.

Before, `print(getResp)` would print `Instance of GetHit`, and now it will print `GetHit: value`