### PR TITLE
chore: api snippet formatting

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -22,7 +22,8 @@ jobs:
 
       # Uncomment this step to verify the use of 'dart format' on each commit.
       - name: Verify formatting
-        run: dart format --output=none --set-exit-if-changed .
+        run: find lib/src example test -name "*.dart" -not -name doc_example_apis.dart \
+          -exec dart format --output=none --set-exit-if-changed {} \;
 
       # Consider passing '--fatal-infos' for slightly stricter analysis.
       - name: Analyze project source

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -22,7 +22,7 @@ jobs:
 
       # Uncomment this step to verify the use of 'dart format' on each commit.
       - name: Verify formatting
-        run: find lib/src example test -name "*.dart" -not -name doc_example_apis.dart \
+        run: find lib/momento.dart lib/src example test -name "*.dart" -not -name doc_example_apis.dart \
           -exec dart format --output=none --set-exit-if-changed {} \;
 
       # Consider passing '--fatal-infos' for slightly stricter analysis.

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -22,8 +22,7 @@ jobs:
 
       # Uncomment this step to verify the use of 'dart format' on each commit.
       - name: Verify formatting
-        run: find lib/momento.dart lib/src example test -name "*.dart" -not -name doc_example_apis.dart \
-          -exec dart format --output=none --set-exit-if-changed {} \;
+        run: find lib/momento.dart lib/src example test -name "*.dart" -not -name doc_example_apis.dart -exec dart format --output=none --set-exit-if-changed {} \;
 
       # Consider passing '--fatal-infos' for slightly stricter analysis.
       - name: Analyze project source

--- a/example/doc_example_apis/doc_example_apis.dart
+++ b/example/doc_example_apis/doc_example_apis.dart
@@ -2,10 +2,11 @@ import 'dart:io';
 import 'package:momento/momento.dart';
 import 'package:uuid/uuid.dart';
 
-Future<void> example_API_InstantiateCacheClient() async {
+Future<void> example_API_InstantiateCacheClient(
+    String envVarName) async {
   try {
     final cacheClient = CacheClient(
-        CredentialProvider.fromEnvironmentVariable("MOMENTO_API_KEY"),
+        CredentialProvider.fromEnvironmentVariable(envVarName),
         CacheClientConfigurations.latest(),
         Duration(seconds: 30));
   } catch (e) {
@@ -27,7 +28,8 @@ Future<void> example_API_CreateCache(
   }
 }
 
-Future<void> example_API_ListCaches(CacheClient cacheClient) async {
+Future<void> example_API_ListCaches(
+    CacheClient cacheClient) async {
   final result = await cacheClient.listCaches();
   switch (result) {
     case ListCachesError():
@@ -96,7 +98,7 @@ Future<void> main() async {
   final key = StringValue("myKey");
   final value = StringValue("myValue");
 
-  await example_API_InstantiateCacheClient();
+  await example_API_InstantiateCacheClient("MOMENTO_API_KEY");
   await example_API_CreateCache(cacheClient, cacheName);
   await example_API_ListCaches(cacheClient);
 

--- a/example/doc_example_apis/doc_example_apis.dart
+++ b/example/doc_example_apis/doc_example_apis.dart
@@ -3,7 +3,7 @@ import 'package:momento/momento.dart';
 import 'package:uuid/uuid.dart';
 
 Future<void> example_API_InstantiateCacheClient(
-    String envVarName) async {
+    String envVarName, String longNameForFormatting) async {
   try {
     final cacheClient = CacheClient(
         CredentialProvider.fromEnvironmentVariable(envVarName),
@@ -29,7 +29,7 @@ Future<void> example_API_CreateCache(
 }
 
 Future<void> example_API_ListCaches(
-    CacheClient cacheClient) async {
+    CacheClient cacheClient, String longNameForFormatting) async {
   final result = await cacheClient.listCaches();
   switch (result) {
     case ListCachesError():
@@ -98,9 +98,9 @@ Future<void> main() async {
   final key = StringValue("myKey");
   final value = StringValue("myValue");
 
-  await example_API_InstantiateCacheClient("MOMENTO_API_KEY");
+  await example_API_InstantiateCacheClient("MOMENTO_API_KEY", "");
   await example_API_CreateCache(cacheClient, cacheName);
-  await example_API_ListCaches(cacheClient);
+  await example_API_ListCaches(cacheClient, "");
 
   await example_API_Set(cacheClient, cacheName, key, value);
   await example_API_Get(cacheClient, cacheName, key);

--- a/example/doc_example_apis/doc_example_apis.dart
+++ b/example/doc_example_apis/doc_example_apis.dart
@@ -91,7 +91,7 @@ Future<void> main() async {
   final key = StringValue("myKey");
   final value = StringValue("myValue");
 
-  await example_API_InstantiateCacheClient("MOMENTO_API_KEY");
+  await example_API_InstantiateCacheClient();
   await example_API_CreateCache(cacheClient, cacheName);
   await example_API_ListCaches(cacheClient);
 

--- a/example/doc_example_apis/doc_example_apis.dart
+++ b/example/doc_example_apis/doc_example_apis.dart
@@ -2,11 +2,10 @@ import 'dart:io';
 import 'package:momento/momento.dart';
 import 'package:uuid/uuid.dart';
 
-Future<void> example_API_InstantiateCacheClient(
-    String envVarName, String longNameForFormatting) async {
+Future<void> example_API_InstantiateCacheClient() async {
   try {
     final cacheClient = CacheClient(
-        CredentialProvider.fromEnvironmentVariable(envVarName),
+        CredentialProvider.fromEnvironmentVariable("MOMENTO_API_KEY"),
         CacheClientConfigurations.latest(),
         Duration(seconds: 30));
   } catch (e) {
@@ -15,8 +14,7 @@ Future<void> example_API_InstantiateCacheClient(
   }
 }
 
-Future<void> example_API_CreateCache(
-    CacheClient cacheClient, String cacheName) async {
+Future<void> example_API_CreateCache(CacheClient cacheClient, String cacheName) async {
   final result = await cacheClient.createCache(cacheName);
   switch (result) {
     case CreateCacheAlreadyExists():
@@ -28,8 +26,7 @@ Future<void> example_API_CreateCache(
   }
 }
 
-Future<void> example_API_ListCaches(
-    CacheClient cacheClient, String longNameForFormatting) async {
+Future<void> example_API_ListCaches(CacheClient cacheClient) async {
   final result = await cacheClient.listCaches();
   switch (result) {
     case ListCachesError():
@@ -39,8 +36,7 @@ Future<void> example_API_ListCaches(
   }
 }
 
-Future<void> example_API_DeleteCache(
-    CacheClient cacheClient, String cacheName) async {
+Future<void> example_API_DeleteCache(CacheClient cacheClient, String cacheName) async {
   final result = await cacheClient.deleteCache(cacheName);
   switch (result) {
     case DeleteCacheError():
@@ -51,8 +47,7 @@ Future<void> example_API_DeleteCache(
   }
 }
 
-Future<void> example_API_Set(
-    CacheClient cacheClient, String cacheName, Value key, Value value) async {
+Future<void> example_API_Set(CacheClient cacheClient, String cacheName, Value key, Value value) async {
   final result = await cacheClient.set(cacheName, key, value);
   switch (result) {
     case SetError():
@@ -63,8 +58,7 @@ Future<void> example_API_Set(
   }
 }
 
-Future<void> example_API_Get(
-    CacheClient cacheClient, String cacheName, Value key) async {
+Future<void> example_API_Get(CacheClient cacheClient, String cacheName, Value key) async {
   final result = await cacheClient.get(cacheName, key);
   switch (result) {
     case GetMiss():
@@ -76,8 +70,7 @@ Future<void> example_API_Get(
   }
 }
 
-Future<void> example_API_Delete(
-    CacheClient cacheClient, String cacheName, Value key) async {
+Future<void> example_API_Delete(CacheClient cacheClient, String cacheName, Value key) async {
   final result = await cacheClient.delete(cacheName, key);
   switch (result) {
     case DeleteError():
@@ -98,9 +91,9 @@ Future<void> main() async {
   final key = StringValue("myKey");
   final value = StringValue("myValue");
 
-  await example_API_InstantiateCacheClient("MOMENTO_API_KEY", "");
+  await example_API_InstantiateCacheClient("MOMENTO_API_KEY");
   await example_API_CreateCache(cacheClient, cacheName);
-  await example_API_ListCaches(cacheClient, "");
+  await example_API_ListCaches(cacheClient);
 
   await example_API_Set(cacheClient, cacheName, key, value);
   await example_API_Get(cacheClient, cacheName, key);


### PR DESCRIPTION
The `dart format` command is enforcing formatting that isn't compatible with the API snippet parser for the API docs examples file. For the parser, I need all my method declarations to be either one or two lines but not both. The dart formatter wants them to be wrapped contingent on line length so keeps mixing 1- and 2-line signatures in the same file. The `dart format` command doesn't use an exclude list like `dart analyze` so I'm excluding the file by using `find` instead of letting `dart format` find the relevant files itself.