### PR TITLE
chore: send package version as agent header once per new client

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,5 @@
+{
+  "extra-files": [
+    "lib/src/internal/utils/package_version.dart"
+  ]
+}

--- a/lib/src/internal/control_client.dart
+++ b/lib/src/internal/control_client.dart
@@ -83,7 +83,8 @@ class ControlClient implements AbstractControlClient {
   Future<ListCachesResponse> listCaches() async {
     var request = ListCachesRequest_();
     try {
-      final resp = await _client.listCaches(request, options: CallOptions(metadata: makeHeaders()));
+      final resp = await _client.listCaches(request,
+          options: CallOptions(metadata: makeHeaders()));
       return ListCachesSuccess(resp.cache);
     } catch (e) {
       if (e is GrpcError) {

--- a/lib/src/internal/control_client.dart
+++ b/lib/src/internal/control_client.dart
@@ -1,11 +1,8 @@
-import 'dart:io';
-
 import 'package:momento/momento.dart';
 import 'package:momento/generated/controlclient.pbgrpc.dart';
 import 'package:momento/src/config/cache_configuration.dart';
 import 'package:momento/src/errors/errors.dart';
 import 'package:grpc/grpc.dart';
-import 'package:yaml/yaml.dart';
 
 import 'utils/utils.dart';
 

--- a/lib/src/internal/control_client.dart
+++ b/lib/src/internal/control_client.dart
@@ -1,8 +1,11 @@
+import 'dart:io';
+
 import 'package:momento/momento.dart';
 import 'package:momento/generated/controlclient.pbgrpc.dart';
 import 'package:momento/src/config/cache_configuration.dart';
 import 'package:momento/src/errors/errors.dart';
 import 'package:grpc/grpc.dart';
+import 'package:yaml/yaml.dart';
 
 abstract class AbstractControlClient {
   Future<CreateCacheResponse> createCache(String cacheName);
@@ -37,6 +40,9 @@ class ControlClient implements AbstractControlClient {
     if (firstRequest) {
       firstRequest = false;
       headers.addEntries({'agent': 'dart:0.1.0'}.entries);
+      Map pubspec = loadYaml(File("pubspec.yaml").readAsStringSync());
+      String version = pubspec['version'];
+      headers.addEntries({'agent': version}.entries);
     }
     return headers;
   }

--- a/lib/src/internal/control_client.dart
+++ b/lib/src/internal/control_client.dart
@@ -29,7 +29,6 @@ class ControlClient implements AbstractControlClient {
     _client = ScsControlClient(_channel,
         options: CallOptions(metadata: {
           'authorization': credentialProvider.apiKey,
-          'agent': 'dart:0.1.0',
         }, timeout: _configuration.transportStrategy.grpcConfig.deadline));
   }
 
@@ -42,11 +41,11 @@ class ControlClient implements AbstractControlClient {
       firstRequest = false;
       try {
         String? packageVersion = await findPackageVersion();
-        headers.addEntries({'agent': packageVersion ?? 'unknown'}.entries);
+        headers.addEntries({'agent': 'dart:${packageVersion ?? 'unkown'}'}.entries);
       } catch (e) {
         // Pubspec file was probably not found
         _logger.info("Could not find package version: $e");
-        headers.addEntries({'agent': 'unknown'}.entries);
+        headers.addEntries({'agent': 'dart:unknown'}.entries);
       }
     }
     return headers;

--- a/lib/src/internal/data_client.dart
+++ b/lib/src/internal/data_client.dart
@@ -76,11 +76,11 @@ class DataClient implements AbstractDataClient {
       firstRequest = false;
       try {
         String? packageVersion = await findPackageVersion();
-        headers.addEntries({'agent': packageVersion ?? 'unknown'}.entries);
+        headers.addEntries({'agent': 'dart:${packageVersion ?? 'unkown'}'}.entries);
       } catch (e) {
         // Pubspec file was probably not found
         _logger.info("Could not find package version: $e");
-        headers.addEntries({'agent': 'unknown'}.entries);
+        headers.addEntries({'agent': 'dart:unknown'}.entries);
       }
     }
     return headers;

--- a/lib/src/internal/data_client.dart
+++ b/lib/src/internal/data_client.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:momento/generated/cacheclient.pbgrpc.dart';
 import 'package:momento/momento.dart';
@@ -6,6 +7,7 @@ import 'package:momento/src/config/cache_configuration.dart';
 import 'package:momento/src/errors/errors.dart';
 import 'package:fixnum/fixnum.dart';
 import 'package:grpc/grpc.dart';
+import 'package:yaml/yaml.dart';
 
 abstract class AbstractDataClient {
   // Unary RPCs
@@ -70,7 +72,9 @@ class DataClient implements AbstractDataClient {
     }
     if (firstRequest) {
       firstRequest = false;
-      headers.addEntries({'agent': 'dart:0.1.0'}.entries);
+      Map pubspec = loadYaml(File("pubspec.yaml").readAsStringSync());
+      String version = pubspec['version'];
+      headers.addEntries({'agent': version}.entries);
     }
     return headers;
   }

--- a/lib/src/internal/data_client.dart
+++ b/lib/src/internal/data_client.dart
@@ -52,15 +52,27 @@ class DataClient implements AbstractDataClient {
   late ScsClient _client;
   final CacheClientConfiguration _configuration;
   final Duration _defaultTtl;
+  var firstRequest = true;
 
   DataClient(CredentialProvider credentialProvider, this._configuration,
       this._defaultTtl) {
     _channel = ClientChannel(credentialProvider.cacheEndpoint);
     _client = ScsClient(_channel,
         options: CallOptions(metadata: {
-          'authorization': credentialProvider.apiKey,
-          'agent': 'dart:0.1.0',
+          'authorization': credentialProvider.apiKey
         }, timeout: _configuration.transportStrategy.grpcConfig.deadline));
+  }
+
+  Map<String, String> makeHeaders({String? cacheName}) {
+    var headers = <String, String>{};
+    if (cacheName != null) {
+      headers.addEntries({'cache': cacheName}.entries);
+    }
+    if (firstRequest) {
+      firstRequest = false;
+      headers.addEntries({'agent': 'dart:0.1.0'}.entries);
+    }
+    return headers;
   }
 
   @override
@@ -69,9 +81,7 @@ class DataClient implements AbstractDataClient {
     request.cacheKey = key.toBinary();
     try {
       var resp = await _client.get(request,
-          options: CallOptions(metadata: {
-            'cache': cacheName,
-          }));
+          options: CallOptions(metadata: makeHeaders(cacheName: cacheName)));
 
       switch (resp.result) {
         case ECacheResult.Miss:
@@ -101,9 +111,7 @@ class DataClient implements AbstractDataClient {
         Int64(ttl != null ? ttl.inMilliseconds : _defaultTtl.inMilliseconds);
     try {
       await _client.set(request,
-          options: CallOptions(metadata: {
-            'cache': cacheName,
-          }));
+          options: CallOptions(metadata: makeHeaders(cacheName: cacheName)));
       return SetSuccess();
     } catch (e) {
       if (e is GrpcError) {
@@ -120,9 +128,7 @@ class DataClient implements AbstractDataClient {
     request.cacheKey = key.toBinary();
     try {
       await _client.delete(request,
-          options: CallOptions(metadata: {
-            'cache': cacheName,
-          }));
+          options: CallOptions(metadata: makeHeaders(cacheName: cacheName)));
       return DeleteSuccess();
     } catch (e) {
       if (e is GrpcError) {
@@ -148,9 +154,7 @@ class DataClient implements AbstractDataClient {
           Int64(actualTtl.ttlMilliseconds() ?? _defaultTtl.inMilliseconds);
       request.refreshTtl = actualTtl.refreshTtl();
       var response = await _client.listConcatenateBack(request,
-          options: CallOptions(metadata: {
-            'cache': cacheName,
-          }));
+          options: CallOptions(metadata: makeHeaders(cacheName: cacheName)));
       return ListConcatenateBackSuccess(response.listLength);
     } catch (e) {
       if (e is GrpcError) {
@@ -176,12 +180,8 @@ class DataClient implements AbstractDataClient {
           Int64(actualTtl.ttlMilliseconds() ?? _defaultTtl.inMilliseconds);
       request.refreshTtl = actualTtl.refreshTtl();
       var response = await _client.listConcatenateFront(request,
-          options: CallOptions(metadata: {
-            'cache': cacheName,
-          }));
-      return ListConcatenateFrontSuccess(
-        response.listLength,
-      );
+          options: CallOptions(metadata: makeHeaders(cacheName: cacheName)));
+      return ListConcatenateFrontSuccess(response.listLength);
     } catch (e) {
       if (e is GrpcError) {
         return ListConcatenateFrontError(grpcStatusToSdkException(e));
@@ -210,9 +210,7 @@ class DataClient implements AbstractDataClient {
         request.unboundedEnd = Unbounded_();
       }
       var response = await _client.listFetch(request,
-          options: CallOptions(metadata: {
-            'cache': cacheName,
-          }));
+          options: CallOptions(metadata: makeHeaders(cacheName: cacheName)));
       switch (response.whichList()) {
         case ListFetchResponse__List.found:
           return ListFetchHit(response.found.values);
@@ -239,9 +237,7 @@ class DataClient implements AbstractDataClient {
       var request = ListLengthRequest_();
       request.listName = utf8.encode(listName);
       var response = await _client.listLength(request,
-          options: CallOptions(metadata: {
-            'cache': cacheName,
-          }));
+          options: CallOptions(metadata: makeHeaders(cacheName: cacheName)));
       switch (response.whichList()) {
         case ListLengthResponse__List.found:
           return ListLengthHit(response.found.length);
@@ -268,9 +264,7 @@ class DataClient implements AbstractDataClient {
       var request = ListPopBackRequest_();
       request.listName = utf8.encode(listName);
       var response = await _client.listPopBack(request,
-          options: CallOptions(metadata: {
-            'cache': cacheName,
-          }));
+          options: CallOptions(metadata: makeHeaders(cacheName: cacheName)));
       switch (response.whichList()) {
         case ListPopBackResponse__List.found:
           return ListPopBackHit(
@@ -299,9 +293,7 @@ class DataClient implements AbstractDataClient {
       var request = ListPopFrontRequest_();
       request.listName = utf8.encode(listName);
       var response = await _client.listPopFront(request,
-          options: CallOptions(metadata: {
-            'cache': cacheName,
-          }));
+          options: CallOptions(metadata: makeHeaders(cacheName: cacheName)));
       switch (response.whichList()) {
         case ListPopFrontResponse__List.found:
           return ListPopFrontHit(response.found.front);
@@ -335,9 +327,7 @@ class DataClient implements AbstractDataClient {
           Int64(actualTtl.ttlMilliseconds() ?? _defaultTtl.inMilliseconds);
       request.refreshTtl = actualTtl.refreshTtl();
       var response = await _client.listPushBack(request,
-          options: CallOptions(metadata: {
-            'cache': cacheName,
-          }));
+          options: CallOptions(metadata: makeHeaders(cacheName: cacheName)));
       return ListPushBackSuccess(response.listLength);
     } catch (e) {
       if (e is GrpcError) {
@@ -363,9 +353,7 @@ class DataClient implements AbstractDataClient {
           Int64(actualTtl.ttlMilliseconds() ?? _defaultTtl.inMilliseconds);
       request.refreshTtl = actualTtl.refreshTtl();
       var response = await _client.listPushFront(request,
-          options: CallOptions(metadata: {
-            'cache': cacheName,
-          }));
+          options: CallOptions(metadata: makeHeaders(cacheName: cacheName)));
       return ListPushFrontSuccess(response.listLength);
     } catch (e) {
       if (e is GrpcError) {
@@ -385,9 +373,7 @@ class DataClient implements AbstractDataClient {
       request.listName = utf8.encode(listName);
       request.allElementsWithValue = value.toBinary();
       await _client.listRemove(request,
-          options: CallOptions(metadata: {
-            'cache': cacheName,
-          }));
+          options: CallOptions(metadata: makeHeaders(cacheName: cacheName)));
       return ListRemoveValueSuccess();
     } catch (e) {
       if (e is GrpcError) {
@@ -420,9 +406,7 @@ class DataClient implements AbstractDataClient {
           Int64(actualTtl.ttlMilliseconds() ?? _defaultTtl.inMilliseconds);
       request.refreshTtl = actualTtl.refreshTtl();
       await _client.listRetain(request,
-          options: CallOptions(metadata: {
-            'cache': cacheName,
-          }));
+          options: CallOptions(metadata: makeHeaders(cacheName: cacheName)));
       return ListRetainSuccess();
     } catch (e) {
       if (e is GrpcError) {

--- a/lib/src/internal/data_client.dart
+++ b/lib/src/internal/data_client.dart
@@ -58,9 +58,9 @@ class DataClient implements AbstractDataClient {
       this._defaultTtl) {
     _channel = ClientChannel(credentialProvider.cacheEndpoint);
     _client = ScsClient(_channel,
-        options: CallOptions(metadata: {
-          'authorization': credentialProvider.apiKey
-        }, timeout: _configuration.transportStrategy.grpcConfig.deadline));
+        options: CallOptions(
+            metadata: {'authorization': credentialProvider.apiKey},
+            timeout: _configuration.transportStrategy.grpcConfig.deadline));
   }
 
   Map<String, String> makeHeaders({String? cacheName}) {

--- a/lib/src/internal/pubsub_client.dart
+++ b/lib/src/internal/pubsub_client.dart
@@ -81,7 +81,8 @@ class ClientPubsub implements AbstractPubsubClient {
     request.resumeAtTopicSequenceNumber =
         resumeAtTopicSequenceNumber ?? Int64(0);
     try {
-      var stream = _grpcManager.client.subscribe(request, options: CallOptions(metadata: makeHeaders()));
+      var stream = _grpcManager.client
+          .subscribe(request, options: CallOptions(metadata: makeHeaders()));
       final subscription = TopicSubscription(stream,
           request.resumeAtTopicSequenceNumber, this, cacheName, topicName);
 

--- a/lib/src/internal/pubsub_client.dart
+++ b/lib/src/internal/pubsub_client.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:momento/generated/cachepubsub.pbgrpc.dart';
 import 'package:momento/src/auth/credential_provider.dart';
 import 'package:momento/src/errors/errors.dart';
@@ -5,6 +7,7 @@ import 'package:momento/src/internal/topics_grpc_manager.dart';
 import 'package:momento/src/messages/responses/topics/topic_subscribe.dart';
 import 'package:fixnum/fixnum.dart';
 import 'package:grpc/grpc.dart';
+import 'package:yaml/yaml.dart';
 
 import '../config/topic_configuration.dart';
 import '../messages/values.dart';
@@ -43,9 +46,9 @@ class ClientPubsub implements AbstractPubsubClient {
   Map<String, String>? makeHeaders() {
     if (firstRequest) {
       firstRequest = false;
-      return {
-        'agent': 'dart:0.1.0',
-      };
+      Map pubspec = loadYaml(File("pubspec.yaml").readAsStringSync());
+      String version = pubspec['version'];
+      return {'agent': version};
     }
     return null;
   }

--- a/lib/src/internal/pubsub_client.dart
+++ b/lib/src/internal/pubsub_client.dart
@@ -48,11 +48,11 @@ class ClientPubsub implements AbstractPubsubClient {
       firstRequest = false;
       try {
         String? packageVersion = await findPackageVersion();
-        return {'agent': packageVersion ?? 'unknown'};
+        return {'agent': 'dart:${packageVersion ?? 'unkown'}'};
       } catch (e) {
         // Pubspec file was probably not found
         _logger.info("Could not find package version: $e");
-        return {'agent': 'unknown'};
+        return {'agent': 'dart:unknown'};
       }
     }
     return null;

--- a/lib/src/internal/pubsub_client.dart
+++ b/lib/src/internal/pubsub_client.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:momento/generated/cachepubsub.pbgrpc.dart';
 import 'package:momento/src/auth/credential_provider.dart';
 import 'package:momento/src/errors/errors.dart';
@@ -7,7 +5,6 @@ import 'package:momento/src/internal/topics_grpc_manager.dart';
 import 'package:momento/src/messages/responses/topics/topic_subscribe.dart';
 import 'package:fixnum/fixnum.dart';
 import 'package:grpc/grpc.dart';
-import 'package:yaml/yaml.dart';
 
 import '../config/topic_configuration.dart';
 import '../messages/values.dart';

--- a/lib/src/internal/topics_grpc_manager.dart
+++ b/lib/src/internal/topics_grpc_manager.dart
@@ -11,9 +11,8 @@ class TopicGrpcManager {
   TopicGrpcManager(CredentialProvider credentialProvider) {
     _channel = ClientChannel(credentialProvider.cacheEndpoint);
     _client = PubsubClient(_channel,
-        options: CallOptions(metadata: {
-          'authorization': credentialProvider.apiKey
-        }));
+        options: CallOptions(
+            metadata: {'authorization': credentialProvider.apiKey}));
   }
 
   PubsubClient get client => _client;

--- a/lib/src/internal/topics_grpc_manager.dart
+++ b/lib/src/internal/topics_grpc_manager.dart
@@ -12,8 +12,7 @@ class TopicGrpcManager {
     _channel = ClientChannel(credentialProvider.cacheEndpoint);
     _client = PubsubClient(_channel,
         options: CallOptions(metadata: {
-          'authorization': credentialProvider.apiKey,
-          'agent': 'dart:0.1.0'
+          'authorization': credentialProvider.apiKey
         }));
   }
 

--- a/lib/src/internal/utils/package_version.dart
+++ b/lib/src/internal/utils/package_version.dart
@@ -1,0 +1,1 @@
+const packageVersion = '0.0.5'; // x-release-please-version

--- a/lib/src/internal/utils/utils.dart
+++ b/lib/src/internal/utils/utils.dart
@@ -1,41 +1,12 @@
-import 'dart:io';
-import 'dart:isolate';
+import 'package_version.dart';
 
-import 'package:yaml/yaml.dart';
-
-// Extract the package version number from
-// the pubspec.yaml file if it's found
-Future<String?> findPackageVersion() async {
-  File? pubspecFile = await findPubspecFile();
-  if (pubspecFile != null) {
-    Map pubspec = loadYaml(pubspecFile.readAsStringSync());
-    return pubspec['version'];
+Map<String, String> constructHeaders(bool firstRequest, {String? cacheName}) {
+  var headers = <String, String>{};
+  if (cacheName != null) {
+    headers.addEntries({'cache': cacheName}.entries);
   }
-  return null;
-}
-
-// Construct relative path to the pubspec.yaml file
-Future<File?> findPubspecFile() async {
-  final currentScriptPath = Directory.current.path;
-  if (currentScriptPath.contains('client-sdk-dart')) {
-    final pathToSdk = currentScriptPath.split('client-sdk-dart')[1];
-
-    var pathToPubspec = '';
-    if (pathToSdk.trim().isEmpty) {
-      pathToPubspec = './pubspec.yaml';
-    } else {
-      final parentDirectories = pathToSdk.split('/');
-      for (final parent in parentDirectories) {
-        if (!parent.contains('.dart') && parent.trim().isNotEmpty) {
-          pathToPubspec += '../';
-        }
-      }
-      pathToPubspec += 'pubspec.yaml';
-    }
-
-    var fileUri = await Isolate.resolvePackageUri(Uri.file(pathToPubspec));
-    if (fileUri == null) return null; // No such pacakge.
-    return File.fromUri(fileUri);
+  if (firstRequest) {
+    headers.addEntries({'agent': 'dart:$packageVersion'}.entries);
   }
-  return null;
+  return headers;
 }

--- a/lib/src/internal/utils/utils.dart
+++ b/lib/src/internal/utils/utils.dart
@@ -1,0 +1,41 @@
+import 'dart:io';
+import 'dart:isolate';
+
+import 'package:yaml/yaml.dart';
+
+// Extract the package version number from
+// the pubspec.yaml file if it's found
+Future<String?> findPackageVersion() async {
+  File? pubspecFile = await findPubspecFile();
+  if (pubspecFile != null) {
+    Map pubspec = loadYaml(pubspecFile.readAsStringSync());
+    return pubspec['version'];
+  }
+  return null;
+}
+
+// Construct relative path to the pubspec.yaml file
+Future<File?> findPubspecFile() async {
+  final currentScriptPath = Directory.current.path;
+  if (currentScriptPath.contains('client-sdk-dart')) {
+    final pathToSdk = currentScriptPath.split('client-sdk-dart')[1];
+
+    var pathToPubspec = '';
+    if (pathToSdk.trim().isEmpty) {
+      pathToPubspec = './pubspec.yaml';
+    } else {
+      final parentDirectories = pathToSdk.split('/');
+      for (final parent in parentDirectories) {
+        if (!parent.contains('.dart') && parent.trim().isNotEmpty) {
+          pathToPubspec += '../';
+        }
+      }
+      pathToPubspec += 'pubspec.yaml';
+    }
+
+    var fileUri = await Isolate.resolvePackageUri(Uri.file(pathToPubspec));
+    if (fileUri == null) return null; // No such pacakge.
+    return File.fromUri(fileUri);
+  }
+  return null;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,6 @@ dependencies:
   protobuf: ^3.1.0
   string_validator: ^1.0.2
   uuid: ^4.2.2
-  yaml: ^3.1.2
 
 dev_dependencies:
   lints: ^2.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   protobuf: ^3.1.0
   string_validator: ^1.0.2
   uuid: ^4.2.2
-  # path: ^1.8.0
+  yaml: ^3.1.2
 
 dev_dependencies:
   lints: ^2.1.0


### PR DESCRIPTION
addresses #85 

kind of hacky approach to trying to get the version number from the SDK's pubspec.yaml actually doesn't work when I try importing the package locally into another Dart project
