### PR TITLE
Fix scalar api snippets

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -22,7 +22,7 @@ jobs:
 
       # Uncomment this step to verify the use of 'dart format' on each commit.
       - name: Verify formatting
-        run: find lib/momento.dart lib/src example test -name "*.dart" -not -name doc_example_apis.dart -exec dart format --output=none --set-exit-if-changed {} \;
+        run: dart format --output=none --set-exit-if-changed .
 
       # Consider passing '--fatal-infos' for slightly stricter analysis.
       - name: Analyze project source

--- a/example/doc_example_apis/doc_example_apis.dart
+++ b/example/doc_example_apis/doc_example_apis.dart
@@ -14,9 +14,8 @@ Future<void> example_API_InstantiateCacheClient() async {
   }
 }
 
-Future<void> example_API_CreateCache(
-    CacheClient cacheClient, String cacheName) async {
-  final result = await cacheClient.createCache(cacheName);
+Future<void> example_API_CreateCache(CacheClient cacheClient) async {
+  final result = await cacheClient.createCache("test-cache");
   switch (result) {
     case CreateCacheAlreadyExists():
       print("Cache already exists");
@@ -37,9 +36,8 @@ Future<void> example_API_ListCaches(CacheClient cacheClient) async {
   }
 }
 
-Future<void> example_API_DeleteCache(
-    CacheClient cacheClient, String cacheName) async {
-  final result = await cacheClient.deleteCache(cacheName);
+Future<void> example_API_DeleteCache(CacheClient cacheClient) async {
+  final result = await cacheClient.deleteCache("test-cache");
   switch (result) {
     case DeleteCacheError():
       print("Error deleting cache: $result");
@@ -49,9 +47,8 @@ Future<void> example_API_DeleteCache(
   }
 }
 
-Future<void> example_API_Set(
-    CacheClient cacheClient, String cacheName, String key, String value) async {
-  final result = await cacheClient.set(cacheName, key, value);
+Future<void> example_API_Set(CacheClient cacheClient) async {
+  final result = await cacheClient.set("test-cache", "test-key", "test-value");
   switch (result) {
     case SetError():
       print("Error setting key: $result");
@@ -61,9 +58,8 @@ Future<void> example_API_Set(
   }
 }
 
-Future<void> example_API_Get(
-    CacheClient cacheClient, String cacheName, String key) async {
-  final result = await cacheClient.get(cacheName, key);
+Future<void> example_API_Get(CacheClient cacheClient) async {
+  final result = await cacheClient.get("test-cache", "test-key");
   switch (result) {
     case GetMiss():
       print("Key was not found in cache.");
@@ -74,9 +70,8 @@ Future<void> example_API_Get(
   }
 }
 
-Future<void> example_API_Delete(
-    CacheClient cacheClient, String cacheName, String key) async {
-  final result = await cacheClient.delete(cacheName, key);
+Future<void> example_API_Delete(CacheClient cacheClient) async {
+  final result = await cacheClient.delete("test-cache", "test-key");
   switch (result) {
     case DeleteError():
       print("Error deleting key: $result");
@@ -97,13 +92,13 @@ Future<void> main() async {
   final value = "myValue";
 
   await example_API_InstantiateCacheClient();
-  await example_API_CreateCache(cacheClient, cacheName);
+  await example_API_CreateCache(cacheClient);
   await example_API_ListCaches(cacheClient);
 
-  await example_API_Set(cacheClient, cacheName, key, value);
-  await example_API_Get(cacheClient, cacheName, key);
-  await example_API_Delete(cacheClient, cacheName, key);
+  await example_API_Set(cacheClient);
+  await example_API_Get(cacheClient);
+  await example_API_Delete(cacheClient);
 
-  await example_API_DeleteCache(cacheClient, cacheName);
+  await example_API_DeleteCache(cacheClient);
   await cacheClient.close();
 }


### PR DESCRIPTION
This commit inlines cache names, key names, and values into the examples which is consistent with the examples from the other SDKs. This also normalizes line length on the function declarations the API snippet parser works on, so we can let `dart format` process this file now without breaking the snippet parsing.