### PR TITLE
chore: forgot to include manifest file in release-please action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,3 +24,4 @@ jobs:
           package-name: momento
           default-branch: main
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false}]'
+          manifest-file: .release-please-manifest.json


### PR DESCRIPTION
release-please PR didn't bump the version number in the arbitrary file `lib/src/internal/utils/package_version.dart` and I think it's because I forgot to [include the manifest file in the github action workflow](https://github.com/google-github-actions/release-please-action?tab=readme-ov-file#advanced-release-configuration)