### PR TITLE
chore: fix yaml syntax in release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,4 +24,5 @@ jobs:
           package-name: momento
           default-branch: main
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false}]'
-          extra-files: ["lib/src/internal/utils/package_version.dart"]
+          extra-files: | 
+            lib/src/internal/utils/package_version.dart


### PR DESCRIPTION
[yaml syntax was wrong](https://github.com/momentohq/client-sdk-dart/actions/runs/7508631513)

updated the yaml syntax based on the examples I'm seeing when [searching github](https://github.com/search?q=release-please+extra-files+language%3AYAML&type=code&l=YAML) for examples of the `extra-files` option