### PR TITLE
feat: support topics sequence page

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Run tests
         run: dart test
         env:
-          TEST_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+          MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
 
       - name: Run examples
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ You can build the SDK for a specific platform using the [`dart compile`](https:/
 You can use the this command from the root of the repository to run the tests:
 
 ```bash
-TEST_API_KEY=<your api key> dart test
+MOMENTO_API_KEY=<your api key> dart test
 ```
 
 ## Compiling protobufs

--- a/lib/src/errors/errors.dart
+++ b/lib/src/errors/errors.dart
@@ -86,8 +86,8 @@ class SdkException extends AbstractExceptionResponseBase implements Exception {
   final String _messageWrapper;
   final MomentoErrorTransportDetails? _transportDetails;
 
-  SdkException(super.message, super.errorCode,
-      super.innerException, this._messageWrapper, this._transportDetails);
+  SdkException(super.message, super.errorCode, super.innerException,
+      this._messageWrapper, this._transportDetails);
 
   String get messageWrapper => _messageWrapper;
   MomentoErrorTransportDetails? get transportDetails => _transportDetails;

--- a/lib/src/errors/errors.dart
+++ b/lib/src/errors/errors.dart
@@ -86,8 +86,8 @@ class SdkException extends AbstractExceptionResponseBase implements Exception {
   final String _messageWrapper;
   final MomentoErrorTransportDetails? _transportDetails;
 
-  SdkException(super.message, super.errorCode, super.innerException,
-      this._messageWrapper, this._transportDetails);
+  SdkException(super.message, super.errorCode,
+      super.innerException, this._messageWrapper, this._transportDetails);
 
   String get messageWrapper => _messageWrapper;
   MomentoErrorTransportDetails? get transportDetails => _transportDetails;

--- a/lib/src/internal/pubsub_client.dart
+++ b/lib/src/internal/pubsub_client.dart
@@ -77,17 +77,23 @@ class ClientPubsub implements AbstractPubsubClient {
 
   @override
   Future<TopicSubscribeResponse> subscribe(String cacheName, String topicName,
-      {Int64? resumeAtTopicSequenceNumber}) async {
+      {Int64? resumeAtTopicSequenceNumber, Int64? sequencePage}) async {
     var request = SubscriptionRequest_();
     request.cacheName = cacheName;
     request.topic = topicName;
     request.resumeAtTopicSequenceNumber =
         resumeAtTopicSequenceNumber ?? Int64(0);
+    request.sequencePage = sequencePage ?? Int64(0);
     try {
       var stream = _grpcManager.client
           .subscribe(request, options: CallOptions(metadata: makeHeaders()));
-      final subscription = TopicSubscription(stream,
-          request.resumeAtTopicSequenceNumber, this, cacheName, topicName);
+      final subscription = TopicSubscription(
+          stream,
+          request.resumeAtTopicSequenceNumber,
+          this,
+          cacheName,
+          topicName,
+          request.sequencePage);
 
       try {
         await subscription.init();

--- a/lib/src/internal/pubsub_client.dart
+++ b/lib/src/internal/pubsub_client.dart
@@ -77,13 +77,14 @@ class ClientPubsub implements AbstractPubsubClient {
 
   @override
   Future<TopicSubscribeResponse> subscribe(String cacheName, String topicName,
-      {Int64? resumeAtTopicSequenceNumber, Int64? sequencePage}) async {
+      {Int64? resumeAtTopicSequenceNumber,
+      Int64? resumeAtTopicSequencePage}) async {
     var request = SubscriptionRequest_();
     request.cacheName = cacheName;
     request.topic = topicName;
     request.resumeAtTopicSequenceNumber =
         resumeAtTopicSequenceNumber ?? Int64(0);
-    request.sequencePage = sequencePage ?? Int64(0);
+    request.sequencePage = resumeAtTopicSequencePage ?? Int64(0);
     try {
       var stream = _grpcManager.client
           .subscribe(request, options: CallOptions(metadata: makeHeaders()));

--- a/lib/src/messages/responses/topics/topic_subscribe.dart
+++ b/lib/src/messages/responses/topics/topic_subscribe.dart
@@ -100,6 +100,7 @@ class TopicSubscription extends ResponseBase implements TopicSubscribeResponse {
     switch (item.whichKind()) {
       case SubscriptionItem__Kind.item:
         lastSequenceNumber = item.item.topicSequenceNumber;
+        lastSequencePage = item.item.sequencePage;
         return createTopicItemResponse(item.item);
       case SubscriptionItem__Kind.heartbeat:
         logger.fine("topic client received a heartbeat");

--- a/lib/src/messages/responses/topics/topic_subscribe.dart
+++ b/lib/src/messages/responses/topics/topic_subscribe.dart
@@ -78,7 +78,7 @@ class TopicSubscription extends ResponseBase implements TopicSubscribeResponse {
     await _stream.cancel();
     var result = await _client.subscribe(cacheName, topicName,
         resumeAtTopicSequenceNumber: lastSequenceNumber,
-        sequencePage: lastSequencePage);
+        resumeAtTopicSequencePage: lastSequencePage);
     if (result is TopicSubscription) {
       logger.fine(
           "Attempting to reconnect to topic $topicName on cache $cacheName with sequence number $lastSequenceNumber and sequence page $lastSequencePage");

--- a/lib/src/messages/responses/topics/topic_subscription_item.dart
+++ b/lib/src/messages/responses/topics/topic_subscription_item.dart
@@ -1,3 +1,4 @@
+import 'package:fixnum/fixnum.dart';
 import 'package:logging/logging.dart';
 import 'package:momento/generated/cachepubsub.pb.dart';
 
@@ -5,23 +6,37 @@ sealed class TopicSubscriptionItemResponse {}
 
 class TopicSubscriptionItemText implements TopicSubscriptionItemResponse {
   final String _value;
-  TopicSubscriptionItemText(this._value);
+  final Int64 _sequenceNumber;
+  final Int64 _sequencePage;
+
+  TopicSubscriptionItemText(
+      this._value, this._sequenceNumber, this._sequencePage);
   String get value => _value;
+  Int64 get sequenceNumber => _sequenceNumber;
+  Int64 get sequencePage => _sequencePage;
 }
 
 class TopicSubscriptionItemBinary implements TopicSubscriptionItemResponse {
   final List<int> _value;
-  TopicSubscriptionItemBinary(this._value);
+  final Int64 _sequenceNumber;
+  final Int64 _sequencePage;
+
+  TopicSubscriptionItemBinary(
+      this._value, this._sequenceNumber, this._sequencePage);
   List<int> get value => _value;
+  Int64 get sequenceNumber => _sequenceNumber;
+  Int64 get sequencePage => _sequencePage;
 }
 
 TopicSubscriptionItemResponse? createTopicItemResponse(TopicItem_ item) {
   final logger = Logger("TopicSubscriptionItemResponse");
   switch (item.value.whichKind()) {
     case TopicValue__Kind.text:
-      return TopicSubscriptionItemText(item.value.text);
+      return TopicSubscriptionItemText(
+          item.value.text, item.topicSequenceNumber, item.sequencePage);
     case TopicValue__Kind.binary:
-      return TopicSubscriptionItemBinary(item.value.binary);
+      return TopicSubscriptionItemBinary(
+          item.value.binary, item.topicSequenceNumber, item.sequencePage);
     case TopicValue__Kind.notSet:
       logger.fine("Received topic subscription item with no set value");
       return null;

--- a/lib/src/topic_client.dart
+++ b/lib/src/topic_client.dart
@@ -1,3 +1,4 @@
+import 'package:fixnum/fixnum.dart';
 import 'package:momento/src/auth/credential_provider.dart';
 import 'package:momento/src/config/logger.dart';
 import 'package:momento/src/errors/errors.dart';
@@ -15,7 +16,8 @@ abstract class ITopicClient {
   Future<TopicPublishResponse> publishBytes(
       String cacheName, String topicName, List<int> value);
 
-  Future<TopicSubscribeResponse> subscribe(String cacheName, String topicName);
+  Future<TopicSubscribeResponse> subscribe(String cacheName, String topicName,
+      {Int64? resumeAtTopicSequenceNumber, Int64? resumeAtTopicSequencePage});
 
   void close();
 }
@@ -118,8 +120,9 @@ class TopicClient implements ITopicClient {
   /// }
   /// ```
   @override
-  Future<TopicSubscribeResponse> subscribe(
-      String cacheName, String topicName) async {
+  Future<TopicSubscribeResponse> subscribe(String cacheName, String topicName,
+      {Int64? resumeAtTopicSequenceNumber,
+      Int64? resumeAtTopicSequencePage}) async {
     try {
       validateCacheName(cacheName);
       validateTopicName(topicName);
@@ -131,7 +134,9 @@ class TopicClient implements ITopicClient {
             UnknownException("Unexpected error: $e", null, null)));
       }
     }
-    return await _pubsubClient.subscribe(cacheName, topicName);
+    return await _pubsubClient.subscribe(cacheName, topicName,
+        resumeAtTopicSequenceNumber: resumeAtTopicSequenceNumber,
+        resumeAtTopicSequencePage: resumeAtTopicSequencePage);
   }
 
   /// Close the client and free up all associated resources.

--- a/test/src/cache/test_utils.dart
+++ b/test/src/cache/test_utils.dart
@@ -2,7 +2,7 @@ import 'package:momento/momento.dart';
 import 'package:uuid/uuid.dart';
 import 'package:test/test.dart';
 
-final apiKeyEnvVarName = "TEST_API_KEY";
+final apiKeyEnvVarName = "MOMENTO_API_KEY";
 final uuidGenerator = Uuid();
 
 class TestSetup {

--- a/test/src/cache/topics_test.dart
+++ b/test/src/cache/topics_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:fixnum/fixnum.dart';
 import 'package:momento/momento.dart';
 import 'package:momento/src/errors/errors.dart';
 import 'package:test/test.dart';
@@ -110,6 +111,108 @@ void main() {
               expect(msg.value, topicValue,
                   reason:
                       "subscription should receive the published string value");
+          }
+          break;
+        }
+      } catch (e) {
+        fail("Error with await for loop: $e");
+      }
+
+      subscribeResp.unsubscribe();
+    });
+
+    test("can subscribe to a topic with resume_at_topic_sequence_number",
+        () async {
+      final topicName = generateStringWithUuid("dart-pubsub");
+      final topicValue = generateStringWithUuid("resume-topic-seq-num");
+
+      await topicClient.publish(integrationTestCacheName, topicName, "foo");
+      await topicClient.publish(
+          integrationTestCacheName, topicName, topicValue);
+      await topicClient.publish(integrationTestCacheName, topicName, "bar");
+
+      final subscribeResp = await topicClient.subscribe(
+          integrationTestCacheName, topicName,
+          resumeAtTopicSequenceNumber: Int64(2));
+      switch (subscribeResp) {
+        case TopicSubscription():
+          expect(subscribeResp.runtimeType, TopicSubscription,
+              reason: "subscribe should succeed");
+        case TopicSubscribeError():
+          fail(
+              'Expected Success but got Error: ${subscribeResp.errorCode} ${subscribeResp.message}');
+      }
+
+      // unsubscribe 10 seconds from now
+      Timer(const Duration(seconds: 10), () {
+        subscribeResp.unsubscribe();
+      });
+
+      try {
+        await for (final msg in subscribeResp.stream) {
+          switch (msg) {
+            case TopicSubscriptionItemBinary():
+              fail("Expected String value, got binary value: ${msg.value}");
+            case TopicSubscriptionItemText():
+              expect(msg.value, topicValue,
+                  reason:
+                      "subscription should receive the published string value with sequence number 2");
+          }
+          break;
+        }
+      } catch (e) {
+        subscribeResp.unsubscribe();
+        fail("Error with await for loop: $e");
+      }
+
+      subscribeResp.unsubscribe();
+    });
+
+    test("can subscribe to a topic with invalid sequence page", () async {
+      final topicName = generateStringWithUuid("dart-pubsub");
+      final topicValue = generateStringWithUuid("resume-topic-seq-page");
+
+      final subscribeResp = await topicClient.subscribe(
+          integrationTestCacheName, topicName,
+          resumeAtTopicSequenceNumber: Int64(300),
+          resumeAtTopicSequencePage: Int64(123456));
+      switch (subscribeResp) {
+        case TopicSubscription():
+          expect(subscribeResp.runtimeType, TopicSubscription,
+              reason: "subscribe should succeed");
+        case TopicSubscribeError():
+          fail(
+              'Expected Success but got Error: ${subscribeResp.errorCode} ${subscribeResp.message}');
+      }
+
+      // unsubscribe 10 seconds from now
+      Timer(const Duration(seconds: 10), () {
+        subscribeResp.unsubscribe();
+      });
+
+      // publish a message 2 seconds from now
+      Timer(const Duration(seconds: 2), () async {
+        final publishResp = await topicClient.publish(
+            integrationTestCacheName, topicName, topicValue);
+        switch (publishResp) {
+          case TopicPublishSuccess():
+            expect(publishResp.runtimeType, TopicPublishSuccess,
+                reason: "publish should succeed");
+          case TopicPublishError():
+            fail(
+                'Expected Success but got Error: ${publishResp.errorCode} ${publishResp.message}');
+        }
+      });
+
+      try {
+        await for (final msg in subscribeResp.stream) {
+          switch (msg) {
+            case TopicSubscriptionItemBinary():
+              fail("Expected String value, got binary value: ${msg.value}");
+            case TopicSubscriptionItemText():
+              expect(msg.value, topicValue,
+                  reason:
+                      "subscription should receive the published string value despite starting with invalid sequence page");
           }
           break;
         }


### PR DESCRIPTION
Closes https://github.com/momentohq/dev-eco-issue-tracker/issues/1066

Add support for topic sequence page. 

Also updated tests to expect MOMENTO_API_KEY instead of TEST_API_KEY.