### PR TITLE
chore: update examples, tests, CI for api keys v2

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches: [ "main" ]
 
+env:
+  MOMENTO_API_KEY: ${{ secrets.ALPHA_API_KEY_V2 }}
+  MOMENTO_ENDPOINT: "cell-alpha-dev.preprod.a.momentohq.com"
+  V1_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -33,12 +38,8 @@ jobs:
       # want to change this to 'flutter test'.
       - name: Run tests
         run: dart test
-        env:
-          MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
 
       - name: Run examples
-        env:
-          MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
         run: |
           pushd example/doc_example_apis
             dart run

--- a/README.template.md
+++ b/README.template.md
@@ -2,12 +2,16 @@
 
 # Momento Dart SDK
 
-To get started with Momento you will need a Momento API key. You can get one from the [Momento Console](https://console.gomomento.com/api-keys).
+To get started with Momento you will need:
 
-* Website: [https://www.gomomento.com/](https://www.gomomento.com/)
-* Momento Documentation: [https://docs.momentohq.com/](https://docs.momentohq.com/)
-* Getting Started: [https://docs.momentohq.com/getting-started](https://docs.momentohq.com/getting-started)
-* Discuss: [Momento Discord](https://discord.gg/3HkAKjUZGq)
+- A Momento API key. You can get one from the [Momento Console](https://console.gomomento.com).
+- A Momento service endpoint is required. You can find a [list of them here](https://docs.momentohq.com/platform/regions)
+
+For more information, check out the following links:
+
+- Website: [https://www.gomomento.com/](https://www.gomomento.com/)
+- Momento Documentation: [https://docs.momentohq.com/](https://docs.momentohq.com/)
+- Getting Started: [https://docs.momentohq.com/getting-started](https://docs.momentohq.com/getting-started)
 
 ## Packages
 

--- a/README.template.md
+++ b/README.template.md
@@ -51,13 +51,13 @@ Check out full working code in the [example](./example/) directory of this repos
 
 There is a `LogLevel` enum that contains the following log levels:
 
-* `LogLevel.trace`
-* `LogLevel.debug`
-* `LogLevel.info`
-* `LogLevel.warn`
-* `LogLevel.error`
-* `LogLevel.fatal`
-* `LogLevel.off`
+- `LogLevel.trace`
+- `LogLevel.debug`
+- `LogLevel.info`
+- `LogLevel.warn`
+- `LogLevel.error`
+- `LogLevel.fatal`
+- `LogLevel.off`
 
 This enum can be used to configure the logging level of the Momento package. By default, the logging level is set to `LogLevel.info`. To change the logging level, pass the desired level to the `Configuration` constructor:
 

--- a/example/README.md
+++ b/example/README.md
@@ -3,6 +3,7 @@
 ## Prerequisites
 
 - For each example, you will need to provide a Momento API key, which you can generate from the [Momento Web Console](https://console.gomomento.com/api-keys).
+- You will also need a Momento service endpoint. You can find a [list of them here](https://docs.momentohq.com/platform/regions)
 
 
 ## Running the examples

--- a/example/doc_example_apis/bin/doc_example_apis.dart
+++ b/example/doc_example_apis/bin/doc_example_apis.dart
@@ -3,10 +3,35 @@ import 'dart:io';
 import 'package:momento/momento.dart';
 import 'package:uuid/uuid.dart';
 
+String retrieveApiKeyFromYourSecretsManager() {
+  // this is not a valid API key but conforms to the syntax requirements.
+  return "eyJhcGlfa2V5IjogImV5SjBlWEFpT2lKS1YxUWlMQ0poYkdjaU9pSklVekkxTmlKOS5leUpwYzNNaU9pSlBibXhwYm1VZ1NsZFVJRUoxYVd4a1pYSWlMQ0pwWVhRaU9qRTJOemd6TURVNE1USXNJbVY0Y0NJNk5EZzJOVFV4TlRReE1pd2lZWFZrSWpvaUlpd2ljM1ZpSWpvaWFuSnZZMnRsZEVCbGVHRnRjR3hsTG1OdmJTSjkuOEl5OHE4NExzci1EM1lDb19IUDRkLXhqSGRUOFVDSXV2QVljeGhGTXl6OCIsICJlbmRwb2ludCI6ICJ0ZXN0Lm1vbWVudG9ocS5jb20ifQo=";
+}
+
+String retrieveApiKeyV2FromYourSecretsManager() {
+  // this is not a valid API key but conforms to the syntax requirements.
+  return "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJ0IjoiZyIsImp0aSI6InNvbWUtaWQifQ.GMr9nA6HE0ttB6llXct_2Sg5-fOKGFbJCdACZFgNbN1fhT6OPg_hVc8ThGzBrWC_RlsBpLA1nzqK3SOJDXYxAw";
+}
+
+void example_API_CredentialProviderFromApiKeyV2() {
+  final apiKey = retrieveApiKeyV2FromYourSecretsManager();
+  final endpoint = "cell-4-us-west-2-1.prod.a.momentohq.com";
+  CredentialProvider.fromApiKeyV2(apiKey, endpoint);
+}
+
+void example_API_CredentialProviderFromDisposableToken() {
+  final authToken = retrieveApiKeyFromYourSecretsManager();
+  CredentialProvider.fromDisposableToken(authToken);
+}
+
+void example_API_CredentialProviderFromEnvVarV2() {
+  CredentialProvider.fromEnvironmentVariablesV2();
+}
+
 Future<void> example_API_InstantiateCacheClient() async {
   try {
     final cacheClient = CacheClient(
-        CredentialProvider.fromEnvironmentVariable("MOMENTO_API_KEY"),
+        CredentialProvider.fromEnvironmentVariablesV2(),
         CacheClientConfigurations.latest(),
         Duration(seconds: 30));
   } catch (e) {
@@ -85,7 +110,7 @@ Future<void> example_API_Delete(CacheClient cacheClient) async {
 Future<void> example_API_InstantiateTopicClient() async {
   try {
     final topicClient = TopicClient(
-        CredentialProvider.fromEnvironmentVariable("MOMENTO_API_KEY"),
+        CredentialProvider.fromEnvironmentVariablesV2(),
         TopicClientConfigurations.latest());
   } catch (e) {
     print("Unable to create topic client: $e");
@@ -133,13 +158,17 @@ Future<void> example_API_TopicPublish(TopicClient topicClient) async {
 }
 
 Future<void> main() async {
+  example_API_CredentialProviderFromApiKeyV2();
+  example_API_CredentialProviderFromDisposableToken();
+  example_API_CredentialProviderFromEnvVarV2();
+
   final cacheClient = CacheClient(
-      CredentialProvider.fromEnvironmentVariable("MOMENTO_API_KEY"),
+      CredentialProvider.fromEnvironmentVariablesV2(),
       CacheClientConfigurations.latest(),
       Duration(seconds: 30));
 
   final topicClient = TopicClient(
-      CredentialProvider.fromEnvironmentVariable("MOMENTO_API_KEY"),
+      CredentialProvider.fromEnvironmentVariablesV2(),
       TopicClientConfigurations.latest());
 
   final cacheName = "doc-example-apis-${Uuid().v4()}";

--- a/example/doc_example_apis/pubspec.yaml
+++ b/example/doc_example_apis/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
   sdk: ^3.2.3
 
 dependencies:
-  momento: ^0.1.0
+  momento: ^0.4.0
 
 dev_dependencies:
   lints: ^2.1.0

--- a/example/flutter_chat_app/README.md
+++ b/example/flutter_chat_app/README.md
@@ -5,16 +5,17 @@
 - [Installed Dart](https://dart.dev/get-dart)
 - [Installed Flutter](https://docs.flutter.dev/get-started/install)
 - Momento API key, which you can generate from the [Momento Web Console](https://console.gomomento.com/api-keys)
+- A Momento service endpoint, you can find a [list of them here](https://docs.momentohq.com/platform/regions)
 
 ## Running the Flutter Demo App
 
-You can run Flutter apps in [VSCode](https://docs.flutter.dev/tools/vs-code) or [Android Studio or IntelliJ](https://docs.flutter.dev/tools/android-studio) using built-in tooling, just make sure to provide your Momento API key as an environment variable named `MOMENTO_API_KEY`.
+You can run Flutter apps in [VSCode](https://docs.flutter.dev/tools/vs-code) or [Android Studio or IntelliJ](https://docs.flutter.dev/tools/android-studio) using built-in tooling, just make sure to provide your Momento API key as an environment variable named `MOMENTO_API_KEY` and endpoint as `MOMENTO_ENDPOINT`.
 
 You can also use the terminal to list your devides and select one to run.
 
 ```bash
 flutter devices
-flutter run -d <device_id> --dart-define="MOMENTO_API_KEY=<your-api-key>"
+flutter run -d <device_id> --dart-define="MOMENTO_API_KEY=<your-api-key> MOMENTO_ENDPOINT=<endpoint>"
 ```
 
 ## Flutter Resources

--- a/example/flutter_chat_app/lib/main.dart
+++ b/example/flutter_chat_app/lib/main.dart
@@ -34,8 +34,7 @@ class MyHomePage extends StatefulWidget {
 
 class _MyHomePageState extends State<MyHomePage> {
   TopicClient _topicClient = TopicClient(
-      CredentialProvider.fromString(
-          const String.fromEnvironment('MOMENTO_API_KEY')),
+      CredentialProvider.fromEnvironmentVariablesV2(),
       TopicClientConfigurations.latest());
 
   List<String> _messages = ["Welcome to Momento Topics!"];

--- a/example/flutter_chat_app/pubspec.yaml
+++ b/example/flutter_chat_app/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  momento: ^0.1.0
+  momento: ^0.4.0
 
 dev_dependencies:
   flutter_test:

--- a/example/quickstart/bin/quickstart.dart
+++ b/example/quickstart/bin/quickstart.dart
@@ -2,7 +2,7 @@ import 'package:momento/momento.dart';
 
 Future<void> main() async {
   final cacheClient = CacheClient(
-      CredentialProvider.fromEnvironmentVariable("MOMENTO_API_KEY"),
+      CredentialProvider.fromEnvironmentVariablesV2(),
       CacheClientConfigurations.latest(),
       Duration(seconds: 30));
 

--- a/example/quickstart/pubspec.yaml
+++ b/example/quickstart/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
   sdk: ^3.2.3
 
 dependencies:
-  momento: ^0.1.0
+  momento: ^0.4.0
 
 dev_dependencies:
   lints: ^2.1.0

--- a/example/topics/README.md
+++ b/example/topics/README.md
@@ -4,6 +4,7 @@
 
 - [Installed Dart](https://dart.dev/get-dart)
 - Momento API key, which you can generate from the [Momento Web Console](https://console.gomomento.com/api-keys)
+- A Momento service endpoint is required. You can find a [list of them here](https://docs.momentohq.com/platform/regions)
 
 ## Basic Example
 
@@ -11,14 +12,14 @@ A very basic example of a Topics subscriber can be run using:
 
 ```
 cd topics/basic_subscriber
-MOMENTO_API_KEY="your-api-key" dart run
+MOMENTO_API_KEY="your-api-key" MOMENTO_ENDPOINT="endpoint" dart run
 ```
 
 A very basic example of a Topics publisher can be run using:
 
 ```
 cd topics/basic_publisher
-MOMENTO_API_KEY="your-api-key" dart run
+MOMENTO_API_KEY="your-api-key" MOMENTO_ENDPOINT="endpoint" dart run
 ```
 
 ## Advanced Example
@@ -27,5 +28,5 @@ The advanced example shows how you can unsubscribe from a topic (i.e. cancel a s
 
 ```
 cd topics/advanced
-MOMENTO_API_KEY="your-api-key" dart run
+MOMENTO_API_KEY="your-api-key" MOMENTO_ENDPOINT="endpoint" dart run
 ```

--- a/example/topics/advanced/bin/topics_advanced.dart
+++ b/example/topics/advanced/bin/topics_advanced.dart
@@ -10,8 +10,7 @@ void main() async {
     print('${record.level.name}: ${record.time}: ${record.message}');
   });
 
-  var topicClient = TopicClient(
-      CredentialProvider.fromEnvironmentVariable("MOMENTO_API_KEY"),
+  var topicClient = TopicClient(CredentialProvider.fromEnvironmentVariablesV2(),
       TopicClientConfigurations.latest());
 
   // start publishing messages in 2 seconds

--- a/example/topics/advanced/pubspec.yaml
+++ b/example/topics/advanced/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
   sdk: ^3.2.3
 
 dependencies:
-  momento: ^0.1.0
+  momento: ^0.4.0
   logging: ^1.2.0
 
 dev_dependencies:

--- a/example/topics/basic_publisher/bin/basic_publisher.dart
+++ b/example/topics/basic_publisher/bin/basic_publisher.dart
@@ -2,8 +2,7 @@ import 'dart:io';
 import 'package:momento/momento.dart';
 
 void main() async {
-  var topicClient = TopicClient(
-      CredentialProvider.fromEnvironmentVariable("MOMENTO_API_KEY"),
+  var topicClient = TopicClient(CredentialProvider.fromEnvironmentVariablesV2(),
       TopicClientConfigurations.latest());
 
   // publish 10 messages spaced 1 second apart

--- a/example/topics/basic_publisher/pubspec.yaml
+++ b/example/topics/basic_publisher/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
   sdk: ^3.2.3
 
 dependencies:
-  momento: ^0.1.0
+  momento: ^0.4.0
 
 dev_dependencies:
   lints: ^2.1.0

--- a/example/topics/basic_subscriber/bin/basic_subscriber.dart
+++ b/example/topics/basic_subscriber/bin/basic_subscriber.dart
@@ -2,8 +2,7 @@ import 'dart:async';
 import 'package:momento/momento.dart';
 
 void main() async {
-  var topicClient = TopicClient(
-      CredentialProvider.fromEnvironmentVariable("MOMENTO_API_KEY"),
+  var topicClient = TopicClient(CredentialProvider.fromEnvironmentVariablesV2(),
       TopicClientConfigurations.latest());
 
   var subscription = await topicClient.subscribe("cache", "topic");

--- a/example/topics/basic_subscriber/pubspec.yaml
+++ b/example/topics/basic_subscriber/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
   sdk: ^3.2.3
 
 dependencies:
-  momento: ^0.1.0
+  momento: ^0.4.0
 
 dev_dependencies:
   lints: ^2.1.0

--- a/test/src/auth/credential_provider_test.dart
+++ b/test/src/auth/credential_provider_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:momento/src/auth/credential_provider.dart';
 import 'package:momento/src/errors/errors.dart';
 import 'package:test/test.dart';
@@ -144,38 +146,34 @@ void main() {
     });
 
     group('fromEnvironmentVariablesV2', () {
-      // Dart does not appear to provide a way to dynamically set environment
-      // variables, cannot test the happy path
-
-      test('static method errors when default env vars are not set', () {
+      test('static method errors when non-default env vars are not set', () {
         expect(
-            () => EnvMomentoV2TokenProvider(),
+            () => CredentialProvider.fromEnvironmentVariablesV2(
+                apiKeyEnvVar: "NONEXISTENT_1", endpointEnvVar: "NONEXISTENT_2"),
             throwsA(CredentialProviderError.emptyEnvironmentVariable(
-                endpointEnvVar)));
-      });
-
-      test('constructor errors when default env vars are not set', () {
-        expect(
-            () => EnvMomentoV2TokenProvider(),
-            throwsA(CredentialProviderError.emptyEnvironmentVariable(
-                endpointEnvVar)));
+                "NONEXISTENT_2")));
       });
 
       test('constructor errors when non-default env vars are not set', () {
-        var alternateApiKeyEnvVar = 'MOMENTO_ALTERNATE_API_KEY';
-        var alternateEndpointEnvVar = 'MOMENTO_ALTERNATE_ENDPOINT';
         expect(
             () => EnvMomentoV2TokenProvider(
-                apiKeyEnvVar: alternateApiKeyEnvVar,
-                endpointEnvVar: alternateEndpointEnvVar),
+                apiKeyEnvVar: "NONEXISTENT_1", endpointEnvVar: "NONEXISTENT_2"),
             throwsA(CredentialProviderError.emptyEnvironmentVariable(
-                alternateEndpointEnvVar)));
+                "NONEXISTENT_2")));
       });
 
-      // endpoint is checked first, but same error would be thrown for missing api key env var
-      test('empty endpoint env var throws error', () {
-        expect(() => EnvMomentoV2TokenProvider(endpointEnvVar: ''),
-            throwsA(CredentialProviderError.emptyEnvVarName('endpoint')));
+      test('static method finds default env vars', () {
+        final creds = CredentialProvider.fromEnvironmentVariablesV2();
+        expect(creds.cacheEndpoint,
+            "cache.${Platform.environment["MOMENTO_ENDPOINT"]}");
+        expect(creds.apiKey, equals(Platform.environment["MOMENTO_API_KEY"]));
+      });
+
+      test('constructor finds default env vars', () {
+        final creds = EnvMomentoV2TokenProvider();
+        expect(creds.cacheEndpoint,
+            "cache.${Platform.environment["MOMENTO_ENDPOINT"]}");
+        expect(creds.apiKey, equals(Platform.environment["MOMENTO_API_KEY"]));
       });
     });
 

--- a/test/src/cache/api_key_v2.dart
+++ b/test/src/cache/api_key_v2.dart
@@ -1,0 +1,401 @@
+import 'dart:io';
+import 'dart:async';
+
+import 'package:momento/momento.dart';
+import 'package:test/test.dart';
+
+import 'test_utils.dart';
+
+void main() {
+  late final TestSetup testSetup;
+  late final String integrationTestCacheName;
+  late final CacheClient cacheClient;
+  late final TopicClient topicClient;
+
+  setUpAll(() async {
+    testSetup = await setUpIntegrationTests(apiKeyV2: true);
+    integrationTestCacheName = testSetup.cacheName;
+    cacheClient = testSetup.cacheClient;
+    topicClient = testSetup.topicClient;
+  });
+
+  tearDownAll(() async {
+    await cleanUpIntegrationTests(testSetup);
+  });
+
+  group('control plane operations', () {
+    test('caches can be created, listed, and deleted', () async {
+      final newTestCacheName = generateStringWithUuid("dart-create-cache");
+      final createResp = await cacheClient.createCache(newTestCacheName);
+      switch (createResp) {
+        case CreateCacheSuccess():
+          expect(createResp.runtimeType, CreateCacheSuccess,
+              reason: "create cache should succeed");
+        case CreateCacheAlreadyExists():
+          fail('Expected Success but got AlreadyExists');
+        case CreateCacheError():
+          fail(
+              'Expected Success but got Error while creating cache $newTestCacheName: ${createResp.errorCode} ${createResp.message}');
+      }
+
+      sleep(Duration(seconds: 1));
+      final listResp = await cacheClient.listCaches();
+      switch (listResp) {
+        case ListCachesSuccess():
+          final cacheNames = listResp.cacheNames;
+          expect(cacheNames.contains(newTestCacheName), true,
+              reason: "new cache should be in list of caches");
+          expect(cacheNames.contains(integrationTestCacheName), true,
+              reason: "integration test cache should be in list of caches");
+        case ListCachesError():
+          fail(
+              'Expected Success but got Error while listing caches: ${listResp.errorCode} ${listResp.message}');
+      }
+
+      sleep(Duration(seconds: 1));
+      final deleteResp = await cacheClient.deleteCache(newTestCacheName);
+      switch (deleteResp) {
+        case DeleteCacheSuccess():
+          expect(deleteResp.runtimeType, DeleteCacheSuccess,
+              reason: "delete cache should succeed");
+        case DeleteCacheError():
+          fail(
+              'Expected Success but got Error when trying to delete cache $newTestCacheName: ${deleteResp.errorCode} ${deleteResp.message}');
+      }
+
+      sleep(Duration(seconds: 1));
+      final listResp2 = await cacheClient.listCaches();
+      switch (listResp2) {
+        case ListCachesSuccess():
+          final cacheNames = listResp2.cacheNames;
+          expect(cacheNames.contains(newTestCacheName), false,
+              reason: "new cache should no longer be in list of caches");
+          expect(cacheNames.contains(integrationTestCacheName), true,
+              reason:
+                  "integration test cache should still be in list of caches");
+        case ListCachesError():
+          fail(
+              'Expected Success but got Error listing caches after deletion: ${listResp2.errorCode} ${listResp2.message}');
+      }
+    });
+  });
+
+  group('scalar get, set, delete', () {
+    test('cache items can be set, get, and deleted', () async {
+      final key = "key";
+      final value = "value";
+
+      // expect first get to miss
+      final getResp1 = await cacheClient.get(integrationTestCacheName, key);
+      switch (getResp1) {
+        case GetHit():
+          fail('Expected Miss but got Hit');
+        case GetMiss():
+          expect(getResp1.runtimeType, GetMiss,
+              reason: "get should miss on empty cache");
+        case GetError():
+          fail(
+              'Expected Miss but got Error: ${getResp1.errorCode} ${getResp1.message}');
+      }
+
+      // expect set with ttl to succeed
+      final setResp = await cacheClient.set(
+          integrationTestCacheName, key, value,
+          ttl: Duration(seconds: 60));
+      switch (setResp) {
+        case SetSuccess():
+          expect(setResp.runtimeType, SetSuccess, reason: "set should succeed");
+        case SetError():
+          fail(
+              'Expected Success but got Error: ${setResp.errorCode} ${setResp.message}');
+      }
+
+      // expect second get to hit
+      final getResp2 = await cacheClient.get(integrationTestCacheName, key);
+      switch (getResp2) {
+        case GetHit():
+          expect(getResp2.runtimeType, GetHit,
+              reason: "get should hit on value set in cache");
+
+        case GetMiss():
+          fail('Expected Hit but got Miss');
+        case GetError():
+          fail(
+              'Expected Hit but got Error: ${getResp2.errorCode} ${getResp2.message}');
+      }
+
+      // expect delete to succeed
+      final deleteResp =
+          await cacheClient.delete(integrationTestCacheName, key);
+      switch (deleteResp) {
+        case DeleteSuccess():
+          expect(deleteResp.runtimeType, DeleteSuccess,
+              reason: "delete should succeed");
+        case DeleteError():
+          fail(
+              'Expected Success but got Error: ${deleteResp.errorCode} ${deleteResp.message}');
+      }
+
+      // expect third get to miss
+      final getResp3 = await cacheClient.get(integrationTestCacheName, key);
+      switch (getResp3) {
+        case GetHit():
+          fail('Expected Miss but got Hit');
+        case GetMiss():
+          expect(getResp3.runtimeType, GetMiss,
+              reason: "get should miss on empty cache");
+        case GetError():
+          fail(
+              'Expected Miss but got Error: ${getResp3.errorCode} ${getResp3.message}');
+      }
+    });
+  });
+
+  group('lists', () {
+    test('concatenate and fetch', () async {
+      final listName = generateStringWithUuid("list-name");
+      final listValue1 = "string value 1";
+      final listValue2 = "string value 2";
+
+      final concateFront = await cacheClient.listConcatenateFront(
+          integrationTestCacheName, listName, [listValue1, listValue2]);
+      switch (concateFront) {
+        case ListConcatenateFrontSuccess():
+          expect(concateFront.runtimeType, ListConcatenateFrontSuccess,
+              reason: "list concatenate front should succeed");
+        case ListConcatenateFrontError():
+          fail(
+              'Expected Success but got Error: ${concateFront.errorCode} ${concateFront.message}');
+      }
+
+      final fetchResp1 =
+          await cacheClient.listFetch(integrationTestCacheName, listName);
+      switch (fetchResp1) {
+        case ListFetchHit():
+          expect(fetchResp1.values, [listValue1, listValue2],
+              reason: "list should contain the value that was pushed");
+        case ListFetchMiss():
+          fail('Expected Hit but got Miss');
+        case ListFetchError():
+          fail(
+              'Expected Hit but got Error: ${fetchResp1.errorCode} ${fetchResp1.message}');
+      }
+
+      final concateBack = await cacheClient.listConcatenateBack(
+          integrationTestCacheName, listName, [listValue1, listValue2]);
+      switch (concateBack) {
+        case ListConcatenateBackSuccess():
+          expect(concateBack.runtimeType, ListConcatenateBackSuccess,
+              reason: "list concatenate back should succeed");
+        case ListConcatenateBackError():
+          fail(
+              'Expected Success but got Error: ${concateBack.errorCode} ${concateBack.message}');
+      }
+
+      final fetchResp2 = await cacheClient
+          .listFetch(integrationTestCacheName, listName, startIndex: 1);
+      switch (fetchResp2) {
+        case ListFetchHit():
+          expect(fetchResp2.values, [listValue2, listValue1, listValue2],
+              reason:
+                  "list should contain the value that was pushed starting at index 1");
+        case ListFetchMiss():
+          fail('Expected Hit but got Miss');
+        case ListFetchError():
+          fail(
+              'Expected Hit but got Error: ${fetchResp2.errorCode} ${fetchResp2.message}');
+      }
+    });
+
+    test('listLength', () async {
+      final listName = generateStringWithUuid("list-length");
+      final listValue1 = "string value 1";
+      final listValue2 = "string value 2";
+      await cacheClient.listConcatenateFront(
+          integrationTestCacheName, listName, [listValue1, listValue2]);
+      await verifyListLength(
+          integrationTestCacheName, listName, 2, cacheClient);
+    });
+
+    test('listPopBack', () async {
+      final listName = generateStringWithUuid("list-pop-back");
+      final listValue1 = ("string value 1");
+      final listValue2 = ("string value 2");
+      await cacheClient.listConcatenateFront(
+          integrationTestCacheName, listName, [listValue1, listValue2]);
+      final popResp1 =
+          await cacheClient.listPopBack(integrationTestCacheName, listName);
+      switch (popResp1) {
+        case ListPopBackHit():
+          expect(popResp1.value, listValue2,
+              reason: "popped value should be the last value in the list");
+        case ListPopBackMiss():
+          fail('Expected Hit but got Miss');
+        case ListPopBackError():
+          fail(
+              'Expected Hit but got Error: ${popResp1.errorCode} ${popResp1.message}');
+      }
+      await verifyListLength(
+          integrationTestCacheName, listName, 1, cacheClient);
+    });
+
+    test('listPopFront', () async {
+      final listName = generateStringWithUuid("list-pop-front");
+      final listValue1 = "string value 1";
+      final listValue2 = "string value 2";
+      await cacheClient.listConcatenateFront(
+          integrationTestCacheName, listName, [listValue1, listValue2]);
+      final popResp1 =
+          await cacheClient.listPopFront(integrationTestCacheName, listName);
+      switch (popResp1) {
+        case ListPopFrontHit():
+          expect(popResp1.value, listValue1,
+              reason: "popped value should be the first one in the list");
+        case ListPopFrontMiss():
+          fail('Expected Hit but got Miss');
+        case ListPopFrontError():
+          fail(
+              'Expected Hit but got Error: ${popResp1.errorCode} ${popResp1.message}');
+      }
+      await verifyListLength(
+          integrationTestCacheName, listName, 1, cacheClient);
+    });
+
+    test('listPushFront', () async {
+      final listName = generateStringWithUuid("list-push-front");
+      final listValue1 = "string value 1";
+      final listValue2 = "string value 2";
+      await cacheClient.listConcatenateFront(
+          integrationTestCacheName, listName, [listValue2]);
+      final listPushFrontResp = await cacheClient.listPushFront(
+          integrationTestCacheName, listName, listValue1);
+      switch (listPushFrontResp) {
+        case ListPushFrontSuccess():
+          expect(listPushFrontResp.length, 2,
+              reason: "list should have length 2 after push");
+          break;
+        case ListPushFrontError():
+          fail(
+              'Expected Success but got Error: ${listPushFrontResp.errorCode} ${listPushFrontResp.message}');
+      }
+      await verifyListFetch(integrationTestCacheName, listName,
+          [listValue1, listValue2], cacheClient);
+    });
+
+    test('listPushBack', () async {
+      final listName = generateStringWithUuid("list-push-back");
+      final listValue1 = "string value 1";
+      final listValue2 = "string value 2";
+      await cacheClient.listConcatenateFront(
+          integrationTestCacheName, listName, [listValue1]);
+      final listPushBackResp = await cacheClient.listPushBack(
+          integrationTestCacheName, listName, listValue2);
+      switch (listPushBackResp) {
+        case ListPushBackSuccess():
+          expect(listPushBackResp.length, 2,
+              reason: "list should have length 2 after push");
+          break;
+        case ListPushBackError():
+          fail(
+              'Expected Success but got Error: ${listPushBackResp.errorCode} ${listPushBackResp.message}');
+      }
+      await verifyListFetch(integrationTestCacheName, listName,
+          [listValue1, listValue2], cacheClient);
+    });
+
+    test('listRemoveValue', () async {
+      final listName = generateStringWithUuid("list-remove-value");
+      final listValue1 = "string value 1";
+      final listValue2 = "string value 2";
+      await cacheClient.listConcatenateFront(
+          integrationTestCacheName, listName, [listValue1, listValue2]);
+      final removeResp1 = await cacheClient.listRemoveValue(
+          integrationTestCacheName, listName, listValue1);
+      switch (removeResp1) {
+        case ListRemoveValueSuccess():
+          // this is expected
+          break;
+        case ListRemoveValueError():
+          fail(
+              'Expected Success but got Error: ${removeResp1.errorCode} ${removeResp1.message}');
+      }
+      await verifyListFetch(
+          integrationTestCacheName, listName, [listValue2], cacheClient);
+    });
+
+    test('listRetain', () async {
+      final listName = generateStringWithUuid("list-retain");
+      final listValue1 = "string value 1";
+      final listValue2 = "string value 2";
+      await cacheClient.listConcatenateFront(
+          integrationTestCacheName, listName, [listValue1, listValue2]);
+      final retainResp1 = await cacheClient
+          .listRetain(integrationTestCacheName, listName, startIndex: 1);
+      switch (retainResp1) {
+        case ListRetainSuccess():
+          // this is expected
+          break;
+        case ListRetainError():
+          fail(
+              'Expected Success but got Error: ${retainResp1.errorCode} ${retainResp1.message}');
+      }
+      await verifyListFetch(
+          integrationTestCacheName, listName, [listValue2], cacheClient);
+    });
+  });
+
+  group('topics', () {
+    test("can publish and subscribe to a topic", () async {
+      final topicName = generateStringWithUuid("dart-pubsub");
+      final topicValue = "Momento pubsub";
+
+      final subscribeResp =
+          await topicClient.subscribe(integrationTestCacheName, topicName);
+      switch (subscribeResp) {
+        case TopicSubscription():
+          expect(subscribeResp.runtimeType, TopicSubscription,
+              reason: "subscribe should succeed");
+        case TopicSubscribeError():
+          fail(
+              'Expected Success but got Error: ${subscribeResp.errorCode} ${subscribeResp.message}');
+      }
+
+      // unsubscribe 10 seconds from now
+      Timer(const Duration(seconds: 10), () {
+        subscribeResp.unsubscribe();
+      });
+
+      // publish a message 2 seconds from now
+      Timer(const Duration(seconds: 2), () async {
+        final publishResp = await topicClient.publish(
+            integrationTestCacheName, topicName, topicValue);
+        switch (publishResp) {
+          case TopicPublishSuccess():
+            expect(publishResp.runtimeType, TopicPublishSuccess,
+                reason: "publish should succeed");
+          case TopicPublishError():
+            fail(
+                'Expected Success but got Error: ${publishResp.errorCode} ${publishResp.message}');
+        }
+      });
+
+      try {
+        await for (final msg in subscribeResp.stream) {
+          switch (msg) {
+            case TopicSubscriptionItemBinary():
+              fail("Expected String value, got binary value: ${msg.value}");
+            case TopicSubscriptionItemText():
+              expect(msg.value, topicValue,
+                  reason:
+                      "subscription should receive the published string value");
+          }
+          break;
+        }
+      } catch (e) {
+        fail("Error with await for loop: $e");
+      }
+
+      subscribeResp.unsubscribe();
+    });
+  });
+}


### PR DESCRIPTION
Work towards https://github.com/momentohq/dev-eco-issue-tracker/issues/1276

1. updates github actions workflows to use env vars V1_API_KEY, MOMENTO_API_KEY, and MOMENTO_ENDPOINT
2. updates readme for new env vars
3. updates examples to default to using from_environment_variables_v2()
4. existing tests now use V1_API_KEY
5. new minimal test suites exercising v2 api key use MOMENTO_API_KEY and MOMENTO_ENDPOINT