### PR TITLE
chore: more api keys v2 updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ Happy coding :dancer:
 
 - Dart version [3 or higher](https://dart.dev/get-dart) is required.
 - A Momento API key is required, you can generate one using the [Momento Console](https://console.gomomento.com/api-keys)
+- A Momento service endpoint is required. You can find a [list of them here](https://docs.momentohq.com/platform/regions)
 
 <br/>
 
@@ -35,7 +36,10 @@ You can build the SDK for a specific platform using the [`dart compile`](https:/
 You can use the this command from the root of the repository to run the tests:
 
 ```bash
-MOMENTO_API_KEY=<your api key> dart test
+export MOMENTO_API_KEY=<your api key>
+export MOMENTO_ENDPOINT=<endpoint>
+export V1_API_KEY=<v1 api key>
+dart test
 ```
 
 ## Compiling protobufs

--- a/example/doc_example_apis/bin/doc_example_apis.dart
+++ b/example/doc_example_apis/bin/doc_example_apis.dart
@@ -25,13 +25,14 @@ void example_API_CredentialProviderFromDisposableToken() {
 }
 
 void example_API_CredentialProviderFromEnvVarV2() {
+  // Optionally specify the environment variable names
+  CredentialProvider.fromEnvironmentVariablesV2(
+      apiKeyEnvVar: "MOMENTO_API_KEY", endpointEnvVar: "MOMENTO_ENDPOINT");
+}
+
+void example_API_CredentialProviderFromEnvVarV2Default() {
   // Looks for MOMENTO_API_KEY and MOMENTO_ENDPOINT environment variables by default
   CredentialProvider.fromEnvironmentVariablesV2();
-
-  // To specify custom environment variable names:
-  // CredentialProvider.fromEnvironmentVariablesV2(
-  //     apiKeyEnvVar: "ALT_MOMENTO_API_KEY",
-  //     endpointEnvVar: "ALT_MOMENTO_ENDPOINT");
 }
 
 Future<void> example_API_InstantiateCacheClient() async {
@@ -167,6 +168,7 @@ Future<void> main() async {
   example_API_CredentialProviderFromApiKeyV2();
   example_API_CredentialProviderFromDisposableToken();
   example_API_CredentialProviderFromEnvVarV2();
+  example_API_CredentialProviderFromEnvVarV2Default();
 
   final cacheClient = CacheClient(
       CredentialProvider.fromEnvironmentVariablesV2(),

--- a/example/doc_example_apis/bin/doc_example_apis.dart
+++ b/example/doc_example_apis/bin/doc_example_apis.dart
@@ -25,7 +25,7 @@ void example_API_CredentialProviderFromDisposableToken() {
 }
 
 void example_API_CredentialProviderFromEnvVarV2() {
-  // Looks for MOMENTO_API_KEY_V2 and MOMENTO_ENDPOINT environment variables by default
+  // Looks for MOMENTO_API_KEY and MOMENTO_ENDPOINT environment variables by default
   CredentialProvider.fromEnvironmentVariablesV2();
 
   // To specify custom environment variable names:

--- a/example/doc_example_apis/bin/doc_example_apis.dart
+++ b/example/doc_example_apis/bin/doc_example_apis.dart
@@ -25,7 +25,13 @@ void example_API_CredentialProviderFromDisposableToken() {
 }
 
 void example_API_CredentialProviderFromEnvVarV2() {
+  // Looks for MOMENTO_API_KEY_V2 and MOMENTO_ENDPOINT environment variables by default
   CredentialProvider.fromEnvironmentVariablesV2();
+
+  // To specify custom environment variable names:
+  // CredentialProvider.fromEnvironmentVariablesV2(
+  //     apiKeyEnvVar: "ALT_MOMENTO_API_KEY",
+  //     endpointEnvVar: "ALT_MOMENTO_ENDPOINT");
 }
 
 Future<void> example_API_InstantiateCacheClient() async {

--- a/example/doc_example_apis/bin/doc_example_apis.dart
+++ b/example/doc_example_apis/bin/doc_example_apis.dart
@@ -25,13 +25,11 @@ void example_API_CredentialProviderFromDisposableToken() {
 }
 
 void example_API_CredentialProviderFromEnvVarV2() {
-  // Optionally specify the environment variable names
   CredentialProvider.fromEnvironmentVariablesV2(
       apiKeyEnvVar: "MOMENTO_API_KEY", endpointEnvVar: "MOMENTO_ENDPOINT");
 }
 
 void example_API_CredentialProviderFromEnvVarV2Default() {
-  // Looks for MOMENTO_API_KEY and MOMENTO_ENDPOINT environment variables by default
   CredentialProvider.fromEnvironmentVariablesV2();
 }
 


### PR DESCRIPTION
work towards https://github.com/momentohq/dev-eco-issue-tracker/issues/1276

Forgot to update contributing doc in last batch of updates.
Split EnvVarV2 snippet into two: default vs with env var names.